### PR TITLE
Fixes all bugged / incorrect item IDs for quest rewards

### DIFF
--- a/airplane/#Master_of_Elements.pl
+++ b/airplane/#Master_of_Elements.pl
@@ -17,7 +17,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(28032 => 1, 28009 => 1, 28006 => 1, 28033 => 1)) {
 		quest::say("You... are.. balanced... and.. powerful.. for.. a.. mortal... $name ..... $name. More.. so.. than.... Magi'kot. But.... you.. are.. not.. yet.. ready.. to.. transcend.. transcend... this.. mortal.. coil. Take.. take.. seize.. this.. Orb... for.. you.. are.. worthy.. of.. reward.. and.. with... the.. aid.. of... the... balance.. balance.. contained.. within.. the.. Orb.. you.. may.. yet.. reach.. the... ultimate... Mastery.");
 		#:: Give a 19436 - Spell: Summon Orb
-		quest::summonitem(119436);
+		quest::summonitem(19436);
 		#:: Step the timer 'depop'
 		quest::stoptimer("depop");
 		#:: Depop without spawn timer

--- a/airplane/Alan_Harten.pl
+++ b/airplane/Alan_Harten.pl
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(20933 => 1, 20807 => 1, 20806 => 1)) { 			#:: Cleric Test of Courage
 		quest::say("Wonderful! Take this as your reward!");
 		#:: Give a 14563 - Truewind Earring
-		quest::summonitem(114563);
+		quest::summonitem(14563);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a huge amount of experience

--- a/crushbone/Kelynn.pl
+++ b/crushbone/Kelynn.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12184 => 1)) {
 		quest::say("You were sent by Geeda!! Here. Take the information. Maybe next you shall earn your Scout Blade from Laren. Quickly!! Leave at once!!");
 		#:: Give item 12183 - Crushbone Information
-		quest::summonitem(112183);
+		quest::summonitem(12183);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/crushbone/a_dwarven_slave.pl
+++ b/crushbone/a_dwarven_slave.pl
@@ -46,7 +46,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 8 && $npcgender == 1) {
 			quest::say("I have no need for this item $name, you can have it back.");
 			#:: Give a 20016 - Shackle Key 16
-			quest::summonitem(120016);
+			quest::summonitem(20016);
 		}
 	}
 	#:: Match a 10351 - Brass Earring
@@ -54,7 +54,7 @@ sub EVENT_ITEM {
 		if ($npcrace == 8 && $npcgender == 0) {
 			quest::say("You killed the taskmaster?!  Absolutely amazing! The orcs will be fighting among themselves for power now and I can disappear in the commotion. Thanks, friend! Take this for your deeds!");
 			#:: Give a 18905 - Worn Rune (Csb 1.O.U. Dwf 1)
-			quest::summonitem(118905);
+			quest::summonitem(18905);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 8 && $npcgender == 1) {
 			quest::say("You killed the taskmaster?!  Absolutely amazing! The orcs will be fighting among themselves for power now and I can disappear in the commotion. Thanks, friend! Take this for your deeds!");
 			#:: Give a 18906 - Small Wood Carving (Csb 1.O.U. Dwf 2)
-			quest::summonitem(118906);
+			quest::summonitem(18906);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -97,7 +97,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 8 && $npcgender == 0) {
 			quest::say("I have no need for this item $name, you can have it back.");
 			#:: Give a 20017 - Shackle Key 17
-			quest::summonitem(120017);
+			quest::summonitem(20017);
 		}
 	}
 	#:: Return unused items

--- a/crushbone/a_dwarven_smith.pl
+++ b/crushbone/a_dwarven_smith.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(10351 => 1)) {
 		quest::say("Outstanding! If you can kill the taskmaster, you might prove useful in recovering the items the orcs took from me when they caught me out in the Faydarks. [Interested] in helping me out?");
 		#:: Give item 13850 - Unfinished Blade Mold
-		quest::summonitem(113850);
+		quest::summonitem(13850);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a moderate amount of experience
@@ -23,7 +23,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(9307 => 1)) {
 		quest::say("MY SHIELD!! Excellent, laddie! Next item on the list is my ringmail. Once I have my [ringmail], I am out of here for good. I will finally be able to leave!");
 		#:: Give item 13850 - Unfinished Sledge Mold
-		quest::summonitem(113851);
+		quest::summonitem(13851);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a moderate amount of experience

--- a/crushbone/an_elven_slave.pl
+++ b/crushbone/an_elven_slave.pl
@@ -56,7 +56,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 5 && $npcgender == 1) {
 			quest::say("I have no need for this item $name, you can have it back.");
 			#:: Give a 20020 - Shackle Key 20
-			quest::summonitem(120020);
+			quest::summonitem(20020);
 		}
 	}
 	#:: Match a 10351 - Brass Earring
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 		if ($npcrace == 5 && $npcgender == 0) {
 			quest::say("You killed the taskmaster?!  Absolutely amazing! The orcs will be fighting among themselves for power now and I can disappear in the commotion. Thanks, friend! Take this for your deeds!");
 			#:: Give a 18901 - Ragged Cloth Note (Csb 1.O.U. Hie 1)
-			quest::summonitem(118901);
+			quest::summonitem(18901);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -77,7 +77,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 5 && $npcgender == 1) {
 			quest::say("You killed the taskmaster?!  Absolutely amazing! The orcs will be fighting among themselves for power now and I can disappear in the commotion. Thanks, friend! Take this for your deeds!");
 			#:: Give a 18902 - Torn Drawing (Csb I.O.U. Hie 2)
-			quest::summonitem(118902);
+			quest::summonitem(18902);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -89,7 +89,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 4 && $npcgender == 0) {
 			quest::say("You killed the taskmaster?!  Absolutely amazing! The orcs will be fighting among themselves for power now and I can disappear in the commotion. Thanks, friend! Take this for your deeds!");
 			#:: Give a 18903 - Tattered Cloth Note (Csb 1.O.U. Elf 1)
-			quest::summonitem(118903);
+			quest::summonitem(18903);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -101,7 +101,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 4 && $npcgender == 1) {
 			quest::say("You killed the taskmaster?!  Absolutely amazing! The orcs will be fighting among themselves for power now and I can disappear in the commotion. Thanks, friend! Take this for your deeds!");
 			#:: Give a 18904 - Faded Wedding Cloth (Csb 1.O.U. Elf 2)
-			quest::summonitem(118904);
+			quest::summonitem(18904);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -133,7 +133,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 5 && $npcgender == 0) {
 			quest::say("I have no need for this item $name, you can have it back.");
 			#:: Give a 20021 - Shackle Key 21
-			quest::summonitem(120021);
+			quest::summonitem(20021);
 		}
 	}
 	#:: Match a 20018 - Shackle Key 18
@@ -160,7 +160,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 4 && $npcgender == 1) {
 			quest::say("I have no need for this item $name, you can have it back.");
 			#:: Give a 20018 - Shackle Key 18
-			quest::summonitem(120018);
+			quest::summonitem(20018);
 		}
 	}
 	#:: Match a 20019 - Shackle Key 19
@@ -187,7 +187,7 @@ sub EVENT_ITEM {
 		elsif ($npcrace == 4 && $npcgender == 0) {
 			quest::say("I have no need for this item $name, you can have it back.");
 			#:: Give a 20019 - Shackle Key 19
-			quest::summonitem(120019);
+			quest::summonitem(20019);
 		}
 	}
 	#:: Return unused items

--- a/eastkarana/Ganelorn_Oast.pl
+++ b/eastkarana/Ganelorn_Oast.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 20876 => 1)) {
 		quest::say("Ah, what do we have here? A letter? Hmm? Scented with a familiar fragrance too. You must have gotten this from Lily. I do wish I had more time to sp} with her, for she is a very sweet girl. If she trusts you to deliver such a letter, I must ask you to do me a favor for me. Please take these eggs. They are a very rare species of albino rattlesnakes which were thought to have been extinct due to poachers who eat them as a delicacy and griffins which prey on them. If these eggs hatch there is hope for the species. I need you to deliver them to my master, Kithicor.");
 		#:: Give Item 20877 - Albino Rattlesnake Eggs
-		quest::summonitem(120877);
+		quest::summonitem(20877);
 		quest::ding();
 		quest::exp(1000);
 		#:: Set factions
@@ -26,7 +26,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 20878 => 1)) {
 		quest::say("This does speak highly of you, my frind, an award from Kithicor does not come easy. But I must see more of your skills before I can consider teaching you. Lily's brother Devin is my current pupil - I need you to gather some equipment for me so I can properly train him. I require the following items of you - a smoldering sash, an adamantine ring and a blade forged of electrum. I also need a favor. Take this credit slip to Aanina Rockfinder. She is a merchant from whom I purchased a gift for Lily; it should be ready by now.");
 		#:: Give a 20879 - Note of Credit
-		quest::summonitem(120879);
+		quest::summonitem(20879);
 		quest::ding();
 		quest::exp(1000);
 	}
@@ -48,7 +48,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 20882 => 1)) {
 		quest::say("You, $name, are a worthy forester. It brings me great pride to present you this scroll that I have only passed to the finest in all of Norrath. Now you, too, may call the flames.");
 		#:: Give a 15691 - Spell: Call of Flame
-		quest::summonitem(115691);
+		quest::summonitem(15691);
 		quest::ding();
 		quest::exp(1000);
 		#:: Set factions

--- a/eastkarana/Milea_Clothspinner.pl
+++ b/eastkarana/Milea_Clothspinner.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18801 => 1)) {
 		quest::say("My sister is in danger. She is all the family I have left. I shall be on my way soon. Please take her my handkerchief, so she knows you have contacted me. Thank you. I am thankful Nerissa ran into you. I just wonder why she did not tell Kane about her suspicions.");
 		#:: Give a 13302 - Monogrammed Cloth
-		quest::summonitem(113302);
+		quest::summonitem(13302);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/erudnext/Beth_Breadmaker.pl
+++ b/erudnext/Beth_Breadmaker.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/can bake/i) {
 		quest::say("You can bake, that's wonderful. Take this crate and fill it with muffins, then seal it up and bring it back to me. Don't go trying to pass off that store bought stuff, I need fresh baked muffins. The ones in the stores are already too old and will get moldy too fast, so I don't want those.");
 		#:: Give a 17881 - Muffin Crate
-		quest::summonitem(117881);
+		quest::summonitem(17881);
 	}
 	elsif ($text=~/can travel/i) {
 		quest::say("There is a wonderful baker that lives in the southern plains. I guess the plague hasn't hit that area too bad. Anyway, he's one heck of a baker and makes some quality bread. Go look him up and tell him you want a bag of bread loaves. He's one of those fellas that goes by the name of Meadowgreen.");

--- a/erudnext/Depnar_Bulrious.pl
+++ b/erudnext/Depnar_Bulrious.pl
@@ -24,7 +24,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18726 => 1)) {
 		quest::say("Welcome to the Temple of Divine Light. I am Master Bulrious. Here. we study and spread the will of Quellious. Here is your guild tunic. Go find Jras Solsier. he will get you started with your first lesson.");
 		#:: Give item 13546 - Faded silver Tunic*
-		quest::summonitem(113546);
+		quest::summonitem(13546);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/erudnext/Dleria_Mausrel.pl
+++ b/erudnext/Dleria_Mausrel.pl
@@ -33,7 +33,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("We have heard of zombies inhabiting the depths of Erud's Crossing. Go and seek them out. Destroy them. This evil should not exist within the realm of the Ocean Lord. Take this bag. Fill it with their rotting flesh. combine it and return it to me. May Prexus guide you.");
 			#:: Give a 17939 - Empty Bag (*Zombie Flesh Bag)
-			quest::summonitem(117939);
+			quest::summonitem(17939);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5) {
@@ -70,12 +70,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("There is no reason to dislike you, but we of the Deepwater Knights must see more done for our cause before we truly accept you.");
 			#:: Return a 13922 - Snapped Pole
-			quest::summonitem(113922);
+			quest::summonitem(13922);
 		}
 		else {
 			quest::say("We, the Deepwater Knights, know of your vile ways. You had best leave while you can.");
 			#:: Return a 13922 - Snapped Pole
-			quest::summonitem(113922);
+			quest::summonitem(13922);
 		}
 		
 	}
@@ -101,12 +101,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("There is no reason to dislike you, but we of the Deepwater Knights must see more done for our cause before we truly accept you.");
 			#:: Return a 13880 - Bag of Zombie Flesh
-			quest::summonitem(113880);
+			quest::summonitem(13880);
 		}
 		else {
 			quest::say("We, the Deepwater Knights, know of your vile ways. You had best leave while you can.");
 			#:: Return a 13880 - Bag of Zombie Flesh
-			quest::summonitem(113880);
+			quest::summonitem(13880);
 		}
 	}
 	#:: Return unused items

--- a/erudnext/Gans_Paust.pl
+++ b/erudnext/Gans_Paust.pl
@@ -20,17 +20,17 @@ sub EVENT_SAY {
 	elsif ($text=~/check on him/i) {
 		quest::say("Thank you, $name. He's one of our people's most knowledgeable geologists and has left to survey an island out in Erud's Crossing. He was sending monthly reports until two weeks ago when his report never showed up. I'm worried something may have happened to him. Take this note to Yelesom and bring back something to assure me of his safety. A reward fitting a Deepwater Knight shall be yours upon your success..");
 		#:: Give item 18173 - Gans's note to Yelesom
-		quest::summonitem(118173);
+		quest::summonitem(18173);
 	}
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give item 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give item 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -39,7 +39,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18724 => 1)) {
 		quest::say("Yes. welcome friend! Here is your guild tunic. You'll make a fine addition to the Deepwater Knights.  Go see Lumi Stergnon, he will get you started in your studies. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13544 - Old Blue Tunic*
-		quest::summonitem(113544);
+		quest::summonitem(13544);
 		#:: Ding!
 		quest::ding();
 		#:: Set faction

--- a/erudnext/Jras_Solsier.pl
+++ b/erudnext/Jras_Solsier.pl
@@ -50,7 +50,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("You have served us well. The harmony of the forest shall be preserved. I have word that theses infidels were all working for one man. Find me evidence pertaining to this man. Surely one of these poachers has something which could aid in finding this man. We must stop him to stop the poachers. Go in peace.");
 			#:: Give item 10004 - Copper Band
-			quest::summonitem(110004);
+			quest::summonitem(10004);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -68,12 +68,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("You have not done much to upset the Peacekeepers of this temple, but we must ask you to prove yourself to us before we may discuss things such as this.");
 			#:: Return a 13825 - Poacher's Head
-			quest::summonitem(113825);
+			quest::summonitem(13825);
 		}
 		else {
 			quest::say("Leave my sight at once! You are no friend to the Peacekeepers of the Temple of Divine Light.");
 			#:: Return a 13825 - Poacher's Head
-			quest::summonitem(113825);
+			quest::summonitem(13825);
 		}
 	}
 	#:: Match a 13913 - Barbarian Head
@@ -82,7 +82,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("It is done! Quellious will look favorably upon our church and we will look favorably upon you. Go in peace");
 			#:: Give item 15202 - Spell: Courage
-			quest::summonitem(115202);
+			quest::summonitem(15202);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -100,12 +100,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("You have not done much to upset the Peacekeepers of this temple, but we must ask you to prove yourself to us before we may discuss things such as this.");
 			#:: Return a 13913 - Barbarian Head
-			quest::summonitem(113913);
+			quest::summonitem(13913);
 		}
 		else {
 			quest::say("Leave my sight at once! You are no friend to the Peacekeepers of the Temple of Divine Light.");
 			#:: Return a 13913 - Barbarian Head
-			quest::summonitem(113913);
+			quest::summonitem(13913);
 		}
 	}
 	#:: Return unused items

--- a/erudnext/Laoni_Reista.pl
+++ b/erudnext/Laoni_Reista.pl
@@ -55,7 +55,7 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("There is no reason to dislike you, but we of the Deepwater Knights must see more done for our cause before we truly accept you.");
 			#:: Return a 13881 -  Nicked Coin
-			quest::summonitem(113881);
+			quest::summonitem(13881);
 		}
 		else {
 			quest::say("A gift for the needy?  Very thoughtful.  May Prexus watch over you.");

--- a/erudnext/Leraena_Shelyrak.pl
+++ b/erudnext/Leraena_Shelyrak.pl
@@ -43,17 +43,17 @@ sub EVENT_SAY {
 	elsif ($text=~/guild coin/i) {
 		quest::say("Yes, of course. Here it is. Remember that it is not a form of currency.");
 		#:: Give item 13989 - Peacekeeper Token
-		quest::summonitem(113989);
+		quest::summonitem(13989);
 	}
 	#if ($text=~/powerful kobold shaman/i) { Quellious Disciple Quest - Stonebrunt Expansion
 		#quest::say("There are obviously other shaman with greater healing ability than those we have yet seen.  Take this pouch and collect some of their odd necklaces so that we may study them.");
 		#:: Give item 17090 - Small Embroidered Sack
-		#quest::summonitem(117090);
+		#quest::summonitem(17090);
 	#}
 	#if ($text=~/greater kobold shaman/i) { Quellious Initiate Quest - Stonebrunt/Warrens Expansion
 		#quest::say("Return to the Warrens and obtain eight of the bronze symbols worn by the kobolds greater shaman. Place them in this sack that has been blessed by the powers of Quellious to protect you from the evil influence of the evil symbols. Return the full sack with your initiate symbol of Quellious.");
 		#:: Give item 17090 - Small Embroidered Sack
-		#quest::summonitem(117090);
+		#quest::summonitem(17090);
 	#}
 	#if ($text=~/ready to advance/i) { Quellious Regent Quest - Stonebrunt/Warrens Expansion
 		#quest::say("You are ready to strike at the body of the kobold shamans power. There is no reasoning with the Kobolds thus there shall be no peace in our beloved lands until their devotion to their wicked deity ceases. Return once again to the Warrens and bring me the unholy symbol worn by the High Shaman.");
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18723 => 1)) {
 		quest::say("Greetings. and welcome to the Temple of Divine Light! Here is your guild tunic. Serve Quellious well. Please see Lumi Stergnon - he has a task for you.");
 		#:: Give item 135546 - Faded Silver Tunic
-		quest::summonitem(113546);
+		quest::summonitem(13546);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -112,9 +112,9 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("You have not done much to upset the Peacekeepers of this temple, but we must ask you to prove yourself to us before we may discuss things such as this.");
 			#:: Return three 13883 - Odd Kobold Paw
-			quest::summonitem(113883);
-			quest::summonitem(113883);
-			quest::summonitem(113883);
+			quest::summonitem(13883);
+			quest::summonitem(13883);
+			quest::summonitem(13883);
 		}
 		else {
 			quest::say("Leave my sight at once! You are no friend to the Peacekeepers of the Temple of Divine Light.");
@@ -126,15 +126,15 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("I instructed you to return THREE paws.");
 			#:: Return two 13883 - Odd Kobold Paw
-			quest::summonitem(113883);
-			quest::summonitem(113883);
+			quest::summonitem(13883);
+			quest::summonitem(13883);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5) {
 			quest::say("You have not done much to upset the Peacekeepers of this temple, but we must ask you to prove yourself to us before we may discuss things such as this.");
 			#:: Return two 13883 - Odd Kobold Paw
-			quest::summonitem(113883);
-			quest::summonitem(113883);
+			quest::summonitem(13883);
+			quest::summonitem(13883);
 		}
 		else {
 			quest::say("Leave my sight at once! You are no friend to the Peacekeepers of the Temple of Divine Light.");
@@ -146,13 +146,13 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("I instructed you to return THREE paws.");
 			#:: Return one 13883 - Odd Kobold Paw
-			quest::summonitem(113883);
+			quest::summonitem(13883);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5) {
 			quest::say("You have not done much to upset the Peacekeepers of this temple, but we must ask you to prove yourself to us before we may discuss things such as this.");
 			#:: Return one 13883 - Odd Kobold Paw
-			quest::summonitem(113883);
+			quest::summonitem(13883);
 		}
 		else {
 			quest::say("Leave my sight at once! You are no friend to the Peacekeepers of the Temple of Divine Light.");
@@ -183,7 +183,7 @@ sub EVENT_ITEM {
 		#quest::say("It is imperative that we discern the nature of these symbols and the source of the kobolds shamanistic powers. There is a citizen of Erudin residing in Freeport named Glyssa Sonshaw. She is quite possibly the most knowledgeable individual in the field of heraldic and hieroglyphic studies. Take the high shamans necklace and this note to her. When you have discovered the nature of the symbols return to me with the documentation and your Disciple Symbol of Quellious.");
 		#:: Give item 1772- Sealed Parchment and 14585 Odd Cold Iron Necklace
 		#quest::summonitem(11772);
-		#quest::summonitem(114585);
+		#quest::summonitem(14585);
 	#}
 	#:: Turn in for 1780 -  Hieroglyph Translations, 1781 Encrypted document, and 1565 Disciple Symbol of Quellious  Quellious Regent Quest - Stonebrunt/Warrens Expansion
 	#if (plugin::check_handin(\%itemcount, 1780 => 1, 1781 => 1, 1565 =>1)) {

--- a/erudnext/Lumi_Stergnon.pl
+++ b/erudnext/Lumi_Stergnon.pl
@@ -10,7 +10,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("Then take this note to the woodworker in Toxxulia Forest. His name is Emil Parsini. He shall have the staff to be returned to the temple.");
 			#:: Give item 18833 - A Sealed Letter for Emil Parsini
-			quest::summonitem(118833);
+			quest::summonitem(18833);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5) {
@@ -25,7 +25,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("Then you shall venture to Toxxulia Forest. There has been an increase in skeleton sightings lately. I do not know their origin, but I believe that your efforts will reduce their numbers! Take this box. Return it to me when you have filled it with the bones of these undead creatures and combined it. May Quellious' light guide you.");
 			#:: Give item 17941 - Box for Bones
-			quest::summonitem(117941);
+			quest::summonitem(17941);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5) {
@@ -91,12 +91,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("You have not done much to upset the Peacekeepers of this temple, but we must ask you to prove yourself to us before we may discuss things such as this.");
 			#:: Return a 13882 - Box of Bones
-			quest::summonitem(113882);
+			quest::summonitem(13882);
 		}
 		else {
 			quest::say("Leave my sight at once!  You are no friend to the Peacekeepers of the Temple of Divine Light.");
 			#:: Return a 13882 - Box of Bones
-			quest::summonitem(113882);
+			quest::summonitem(13882);
 		}
 	}
 	#:: Match a 13816 - Peacekeeper staff
@@ -123,12 +123,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("You have not done much to upset the Peacekeepers of this temple, but we must ask you to prove yourself to us before we may discuss things such as this.");
 			#:: Return a 13816 - Peacekeeper staff 
-			quest::summonitem(113816);
+			quest::summonitem(13816);
 		}
 		else {
 			quest::say("Leave my sight at once!  You are no friend to the Peacekeepers of the Temple of Divine Light.");
 			#:: Return a 13816 - Peacekeeper staff
-			quest::summonitem(113816);
+			quest::summonitem(13816);
 		}
 	}
 	#:: Return unused items

--- a/erudnext/Nolusia_Finharn.pl
+++ b/erudnext/Nolusia_Finharn.pl
@@ -27,7 +27,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13118 => 1)) {
 		quest::say("Good work! Now, hold the bottle by the label! When you hand Flynn the bottle, the label will slide off. Bring me the label as proof of the deed.");
 		#:: Give a 13122 - Erud's Tonic
-		quest::summonitem(113122);
+		quest::summonitem(13122);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/erudnext/Raine_Beteria.pl
+++ b/erudnext/Raine_Beteria.pl
@@ -49,7 +49,7 @@ sub EVENT_ITEM {
   	elsif (plugin::takeItems(10792 => 1)) {
 		quest::say("Thank you very much. I have always wanted one of these! Hehehe? just kidding. I see that you have enchanted this coin. I have placed the final enchantment on it - take it back to Romar.");
 		#:: Give a 10793 - Radiant Coin of Tash
-		quest::summonitem(110793);
+		quest::summonitem(10793);
 		#:: Ding!
 		quest::ding();
     		#:: Grant a small amount of experience

--- a/erudnext/Sinnkin_Highbrow.pl
+++ b/erudnext/Sinnkin_Highbrow.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13121 => 1)) {
 		quest::say("It's about time you figured it out, genius! Maybe you should spend more time in the library. Here, take this tonic and get out of here before they see me giving it to you and turn us both inside out.");
 		#:: Give a 13118 - Erud's Tonic
-		quest::summonitem(113118);
+		quest::summonitem(13118);
 		#:: Ding!
 		quest::ding();
 		#:: Set faction

--- a/erudnext/Ticar_Lorestring.pl
+++ b/erudnext/Ticar_Lorestring.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 	elsif ($text=~/qeynos/i) {
 		quest::say("Take this letter to Tralyn Marsinger in Qeynos.  You can find him at the bard guild hall.  I am sure he will compensate you for your troubles.");
 		#:: Give item 18151 - Bardic Letter (Qeynos)
-		quest::summonitem(118151);
+		quest::summonitem(18151);
 	}
 }
 

--- a/erudnext/Vynon_Estaliun.pl
+++ b/erudnext/Vynon_Estaliun.pl
@@ -20,7 +20,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Good work. I knew you could do it. Take this as reward.");
 			#:: Give a 13053 - Brass Ring
-			quest::summonitem(113053);
+			quest::summonitem(13053);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("You have not done much to upset the Peacekeepers of this temple, but we must ask you to prove yourself to us before we may discuss things such as this.");
 			#:: Return a 13884 - Fishy Cat Tail
-			quest::summonitem(113884);
+			quest::summonitem(13884);
 		}
 	}
 	#:: Return unused items

--- a/erudnext/Weligon_Steelherder.pl
+++ b/erudnext/Weligon_Steelherder.pl
@@ -58,7 +58,7 @@ sub EVENT_SAY {
 		if ($faction <= 4 ) {
 			quest::say("Ah, yes!  Take this bag with you.  When you have collected the remains of the diseased shark and no fewer than three of her young in it, combine them in it and return it to me.  Then, you shall get your reward.");
 			#:: Give item 17938 - Empty Shark Bag
-			quest::summonitem(117938);
+			quest::summonitem(17938);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5 ) {
@@ -73,7 +73,7 @@ sub EVENT_SAY {
 		if ($faction <= 4 ) {
 			quest::say("Then venture to the harbor of Erudin. There, you shall dive into the shark-infested water and search for the Pearls of Odus. They lie upon the grounds of our waters.  Fill the bag I have given you, combine it, and return it to me.  Good luck.");
 			#:: Give item 17939 - Empty  Bag
-			quest::summonitem(117939);
+			quest::summonitem(17939);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5 ) {
@@ -116,7 +116,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18725 => 1)) {
 		quest::say("Greetings and welcome to the Deepwater Knights. Here is your guild tunic. Wear it with pride, and Prexus will keep a watchful eye on you. Go find sister Laoni, she will help you get started with your studies.");
 		#:: Give a 13544 - Old Blue Tunic*
-		quest::summonitem(113544);
+		quest::summonitem(13544);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -132,7 +132,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4 ) {
 			quest::say("Very good, my dear young follower of Prexus. You will learn that swimming is a strong skill among the Deepwater Knights. Keep this up and you may wield a Deepwater harpoon soon enough. For now, you shall wear this barnacle breastplate. It is strong enough to aid a young knight in his quest for perfection.");
 			#:: Give a 12194 - Barnacle Breastplate
-			quest::summonitem(112194);
+			quest::summonitem(12194);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -146,12 +146,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5 ) {
 			quest::say("There is no reason to dislike you, but we of the Deepwater Knights must see more done for our cause before we truly accept you.");
 			#:: Return a 13876 - Bag of Shark remains
-			quest::summonitem(113876);
+			quest::summonitem(13876);
 		}
 		else {
 			quest::say("We, the Deepwater Knights, know of your vile ways. You had best leave while you can.");	
 			#:: Return a 13876 - Bag of Shark remains
-			quest::summonitem(113876);
+			quest::summonitem(13876);
 		}
 	}
 	#:: Match a 13879 - Full bag of pearls
@@ -174,12 +174,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5 ) {
 			quest::say("There is no reason to dislike you, but we of the Deepwater Knights must see more done for our cause before we truly accept you.");
 			#:: Return a 13879 - Full bag of pearls
-			quest::summonitem(113879);
+			quest::summonitem(13879);
 		}
 		else {
 			quest::say("We, the Deepwater Knights, know of your vile ways. You had best leave while you can.");	
 			#:: Return a 13879 - Full bag of pearls
-			quest::summonitem(113879);
+			quest::summonitem(13879);
 		}
 	}
 	#:: Match a 18835 - Sealed List, a 13838 - Human Decapitated Head, a 13839 - Dwarf Decapitated Head, and a 13840 - Gnome Decapitated Head
@@ -202,18 +202,18 @@ sub EVENT_ITEM {
 		elsif ($faction == 5 ) {
 			quest::say("There is no reason to dislike you, but we of the Deepwater Knights must see more done for our cause before we truly accept you.");
 			#:: Return a 18835 - Sealed List, a 13838 - Human Decapitated Head, a 13839 - Dwarf Decapitated Head, and a 13840 - Gnome Decapitated Head
-			quest::summonitem(118835);
-			quest::summonitem(113838);
-			quest::summonitem(113839);
-			quest::summonitem(113840);
+			quest::summonitem(18835);
+			quest::summonitem(13838);
+			quest::summonitem(13839);
+			quest::summonitem(13840);
 		}
 		else {
 			quest::say("We, the Deepwater Knights, know of your vile ways. You had best leave while you can.");	
 			#:: Return a 18835 - Sealed List, a 13838 - Human Decapitated Head, a 13839 - Dwarf Decapitated Head, and a 13840 - Gnome Decapitated Head
-			quest::summonitem(118835);
-			quest::summonitem(113838);
-			quest::summonitem(113839);
-			quest::summonitem(113840);
+			quest::summonitem(18835);
+			quest::summonitem(13838);
+			quest::summonitem(13839);
+			quest::summonitem(13840);
 		}
 	}
 	#:: Return unused items

--- a/erudnint/Agryn_Moonfield.pl
+++ b/erudnint/Agryn_Moonfield.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13989 => 1)) {
 		quest::say("Ah!! A Peacekeeper. I have some Vasty Deep water sitting out already. Here you are. Do not let it fall into the wrong hands.");
 		#:: Give a 13939 - Clear Water
-		quest::summonitem(113939);
+		quest::summonitem(13939);
 		quest::ding();
 		#:: Grant a small amount of experience
 		quest::exp(100);

--- a/erudnint/Ghanlin_Skyphire.pl
+++ b/erudnint/Ghanlin_Skyphire.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18727 => 1)) {
 		quest::say("Greetings. I am Ghanlin Skyphire, Master Wizard of the Crimson Hands. All of us here have devoted our lives to the studies of the arcane and mystical. Let's get you started. Here's your training robe.  Now, go find Raskena. She'll help train you and give you your first lesson.");
 		#:: Give item 13550 - Old Used Robe*
-		quest::summonitem(113550);
+		quest::summonitem(13550);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/erudnint/Josper_Kenshed.pl
+++ b/erudnint/Josper_Kenshed.pl
@@ -10,7 +10,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("Of course you may assist me!! We have much need of a certain item which can only be found in the frigid peaks of Everfrost. There you shall find creatures called ice goblins. Take this bag and fill it with ice goblin beads and be sure to combine them before you return them. Well, then... Off with you!! And be quick about it and I shall give you a fine wizard's weapon. None of this rust-covered garbage offered by our associates!");
 			#:: Give item 17944 - Empty Bag (*Bag for Ice Necklaces)
-			quest::summonitem(117944);
+			quest::summonitem(17944);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5) {
@@ -42,7 +42,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Well done, my young apprentice. I call you apprentice for you are nothing but a spark to my fire. This is the final component for my greatest creation. AHA!! I call it - iced tea!! Never again shall I boil under the hot sun. As for you, take this. It should serve you well. Now go away. There is no iced tea for you");
 			#:: Give item 12208 - Servant's Staff
-			quest::summonitem(112208);
+			quest::summonitem(12208);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -61,12 +61,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("The Crimson hands have no quarrel with you, but we cannot truly trust you as yet.");
 			#:: Return a 13898 - Bag of Ice Necklaces
-			quest::summonitem(113898);
+			quest::summonitem(13898);
 		}
 		else {
 			quest::say("The Crimson Hands will have nothing to do with you.  Perhaps only your death shall improve our relations.");
 			#:: Return a 13898 - Bag of Ice Necklaces
-			quest::summonitem(113898);
+			quest::summonitem(13898);
 		}
 	}
 	#:: Match a 12207 - Half of a Spell
@@ -75,7 +75,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Go now and use his research to aid yourself. Seems that I lack the will to use Ilanic's knowledge for my better good.");
 			#:: Give item 15380 - Spell: Column of Frost
-			quest::summonitem(115380);
+			quest::summonitem(15380);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -90,12 +90,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("The Crimson hands have no quarrel with you, but we cannot truly trust you as yet.");
 			#:: Return a 12207 - Half of a Spell
-			quest::summonitem(112207);
+			quest::summonitem(12207);
 		}
 		else {
 			quest::say("The Crimson Hands will have nothing to do with you.  Perhaps only your death shall improve our relations.");
 			#:: Return a 12207 - Half of a Spell
-			quest::summonitem(112207);
+			quest::summonitem(12207);
 		}
 	}
 	#:: Return unused items

--- a/erudnint/Lanken_Rjarn.pl
+++ b/erudnint/Lanken_Rjarn.pl
@@ -25,7 +25,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18729 => 1)) {
 		quest::say("Welcome to the Craft Keepers! You have much to learn. and I'm sure you are anxious to get started. Here's your training robe. Go see Nolusia. she'll give you your first lesson.");
 		#:: Give a 13549 - Old Patched Robe*
-		quest::summonitem(113549);
+		quest::summonitem(13549);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/erudnint/Markus_Jaevins.pl
+++ b/erudnint/Markus_Jaevins.pl
@@ -39,7 +39,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18728 => 1)) {
 		quest::say("Welcome. young one! I see you show interest in the circle of magic. Nowhere upon Norrath will you find a greater school than this - the Gatecallers. You shall wear this tunic as a sign that you have begun the training of this circle. Remember, the power of the Gatecaller is the power of summoning. Go find Vasile, he will help teach you the basics of summoning. Good luck, friend!");
 		#:: Give item 13548 - Old Torn Robe*
-		quest::summonitem(113548);
+		quest::summonitem(13548);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/erudnint/Toresian_Fhabel.pl
+++ b/erudnint/Toresian_Fhabel.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("Ahhhhh $name.  Slansin used to have need of those potions, however he mysteriously disappeared long ago. The only person I know of who still wants them is a cleric of the Church of Marr in Freeport.");			
 			#:: Give a 13983 - Inert Potion
-			quest::summonitem(113983);
+			quest::summonitem(13983);
 		}
 		else {
 			quest::say("You are lucky to be standing. Leave here immediately or suffer grave consequences! You are not welcome amongst the Craftkeepers.");

--- a/erudnint/Vasile_Jahnir.pl
+++ b/erudnint/Vasile_Jahnir.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 13078 => 2, 7305 => 2)) {
 		quest::say("You have mastered these spells quickly. You shall now wear the gloves of the Gatecaller. Cumbersome they may feel, but they protect the hands of a young magician. In your young days of magic they will protect you from harm. They are not valued much by merchants, but they are prized by other circles. Nevertheless, we offer them only to our young Gatecallers. You may now be of assistance with a [slight problem].");
 		#:: Give item 12209 - Gloves of the Gatecaller
-		quest::summonitem(112209);
+		quest::summonitem(12209);
 		#:: Ding!
 		quest::ding();
 		#:: Give a small amount of xp
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 13895 => 1)) {
 		quest::say("So the rumor shows true. Good work. You are an excellent student and a noble $race. Here is your spell as I promised. Go forth and fill your brain with knowledge.");
 		#:: Give item 15313 - Spell: Fire Flux
-		quest::summonitem(115313);
+		quest::summonitem(15313);
 		#:: Ding!
 		quest::ding();
 		#:: Give a small amount of xp

--- a/everfrost/Arnis_McLish.pl
+++ b/everfrost/Arnis_McLish.pl
@@ -37,7 +37,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13243 => 1)) {
 		quest::say("Mmmm.. Thank you stranger. I feel a lot warmer now. You should now go and find [Megan] O'Reilly.");
 		#:: Give a 13244 - One Quarter of Elixir
-		quest::summonitem(113244);
+		quest::summonitem(13244);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/everfrost/Bryndin_McMill.pl
+++ b/everfrost/Bryndin_McMill.pl
@@ -5,7 +5,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 13242 => 1)) {
 		quest::say("Ahhh!! I feel warm all over. Thanks. You should go give Arnis McLish a drink of this elixir. Last time I saw him he was headed toward Blackburrow.");
 		#:: Give a 13243 - One Half of Elixir
-		quest::summonitem(113243);
+		quest::summonitem(13243);
 		quest::ding();
 		#:: Set factions
 		quest::faction(328,1);	#:: Merchants of Halas

--- a/everfrost/Iceberg.pl
+++ b/everfrost/Iceberg.pl
@@ -30,7 +30,7 @@ sub EVENT_ITEM {
 		#:: Send a signal '2' to Everfrost Peaks >> Tundra_Jack (30061) with no delay
 		quest::signalwith(30061, 2, 0);
 		#:: Give a 12226 - Sweaty Shirt
-		quest::summonitem(112226);
+		quest::summonitem(12226);
 		#:: Ding!
 		quest::ding();
 		#:: Set Factions

--- a/everfrost/Megan_OReilly.pl
+++ b/everfrost/Megan_OReilly.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 	elsif ($text=~/dive for the remains/i) {
 		quest::say("Thank the Tribunal!! I would have, but I cannot swim. Take this chest. Fill it with the four pieces which fell below the surface. I know not what else lies within. When you fill the box and combine the items, return it to Renth. Good luck, $name.");
 		#:: Give a 17945 - Empty Box
-		quest::summonitem(117945);
+		quest::summonitem(17945);
 	}
 }
 
@@ -26,7 +26,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13244 => 1)) {
 		quest::say("Oh thank you. Sorry, but the bottle is empty now. I hope you did't need any. Take the empty bottle back to Dargon. He may refill it for you.");
 		#:: Give a 13245 - Empty Bottle of Elixir
-		quest::summonitem(113245);
+		quest::summonitem(13245);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/everfrost/Sulgar.pl
+++ b/everfrost/Sulgar.pl
@@ -11,12 +11,12 @@ sub EVENT_SAY {
 	elsif ($text=~/tome/i) {
 		quest::say("This tome details the wheel of Tarton, and the lore on where the pieces of it may be found. Use it in good faith.");		
 		#:: Give 18031 - Tome of the Wheel
-		quest::summonitem(118031);
+		quest::summonitem(18031);
 	}
 	elsif ($text=~/wheel case/i) {
 		quest::say("I will lend you this wheel case - put the ten spokes of the wheel in it when you have collected them. I did say lend, however. I shall need the case back. Once you have constructed the Staff of the Wheel and the Star of Eyes, I will trade you them for two magical runes I have found useful in my research.");
 		#:: Give 17510 - Glowing Chest (quest container)
-		quest::summonitem(117510);
+		quest::summonitem(17510);
 	}
 }
 
@@ -25,9 +25,9 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(14360 => 1, 14361 => 1)) {
 		quest::say("Wonderful, you have brought me the Wheel. Here is the reward I promised you.");
 		#:: Give 11880 - Rune of Frost
-		quest::summonitem(111880);
+		quest::summonitem(11880);
 		#:: Give 11881 - Rune of the Astral
-		quest::summonitem(111881);
+		quest::summonitem(11881);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a large amount of experience

--- a/everfrost/Talin_O-Donal.pl
+++ b/everfrost/Talin_O-Donal.pl
@@ -3,7 +3,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 13241 => 1)) {
 		quest::say("Mmmm.. I feel much warmer. Thank you. You should now find Bryndin McMill. He could use a swig also. I saw him hanging around two other guards.");
 		#:: Give 13242 - One Quarter of Elixir
-		quest::summonitem(113242);
+		quest::summonitem(13242);
 		quest::ding();
 		#:: Set Factions
 		quest::faction(328,1);	#:: Merchants of Halas

--- a/everfrost/Trankia.pl
+++ b/everfrost/Trankia.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 10528 => 1)) {
 		quest::say("You must be another one from Vilissia. I will tell you what I tell all the others--you must help me [avenge my brother] before I will help you attain Tishan's Kilt.");
 		#:: Give a 18797 - Tattered Note
-		quest::summonitem(118797);
+		quest::summonitem(18797);
 		quest::ding();
 		quest::exp(500);
 	}
@@ -20,7 +20,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 10556 => 1)) {
 		quest::say("Oh Wulfthan, look what has become of you. I told you that you should not have trusted Martar.  $name, as a final service, I want you to kill Martar IceBear for me. He is known to roam these parts. Bring me the Warthread Kilt that he wears and my two reminder notes, and I will give to you Tishan's Kilt.");
 		#:: Give a 18798 - Tattered Note
-		quest::summonitem(118798);
+		quest::summonitem(18798);
 		quest::ding();
 		quest::exp(500);
 	}
@@ -28,7 +28,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 18797 => 1, 18798 => 1, 1347 => 1)) {
 		quest::say("Ah, Wulfthan, you are at last avenged. Thank you, $name please take this kilt as a reward for services well done.");
 		#:: Give a 18798 - Tattered Note
-		quest::summonitem(118798);
+		quest::summonitem(18798);
 		quest::ding();
 		quest::exp(1500);
 	}

--- a/fearplane/Cazic_Thule.pl
+++ b/fearplane/Cazic_Thule.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 	if ($text=~/gandan has failed in his task/i) {
 		quest::emote("'s thoughts begin to pervade your own, they creep into your mind with great force. You feel pressure as if your head will explode. You see his thoughts becoming your own. You see in these visions a tome bound in flesh dropped to the ground. You then open your eyes to see that same book, and take it knowing that it was meant for you.");
 		#:: Give a 18898 - Flayed Skin Tome
-		quest::summonitem(118898);
+		quest::summonitem(18898);
 	}
 }
 

--- a/fearplane/Irak_Altil.pl
+++ b/fearplane/Irak_Altil.pl
@@ -30,7 +30,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(29010 => 1, 11050 => 1)) {
 		quest::emote("screams so loudly it echoes across the valley as the mark and flames of your holy sword touch his rotted bones. As his body twists he quiets and then speaks. 'Your selflessness has made it possible to redeem my honor. With the cleansing of my corruption your own soul has been strengthened. Your power comes from your devotion to your god and with this you have been rewarded. Remember always your purity, devotion, and why you have sacrificed. I must go now to sacrifice myself upon the spear of pain.'");
 		#:: Give a 10099 - Fiery Defender
-		quest::summonitem(110099);
+		quest::summonitem(10099);
 	}
 	else {
 		quest::emote("ignores your offer.");

--- a/feerrott/#Roror.pl
+++ b/feerrott/#Roror.pl
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItemsCoin(0,0,66,0, 13990 => 1)) {
 		quest::say("'Whatsssss thisssss? You sssseek my blessssssssing? Heh heh heh... Very well... CAZIC-THULE! Take this fruit of Karana into horror'sss dark embrace. Fear and death made manifesssssst. A harvesssst of terror! Here, take your gift of blood and sssstraw. Use its dark powersssss in the name of the Fear Lord!' ");
 		#:: Give a 14320 - Sack of Cursed Hay
-		quest::summonitem(114320);
+		quest::summonitem(14320);
 		#:: Ding!
 		quest::ding();
 		#:: Give a small amount of experience

--- a/feerrott/Drizda_Tunesinger.pl
+++ b/feerrott/Drizda_Tunesinger.pl
@@ -11,6 +11,6 @@ sub EVENT_SAY {
 	if ($text=~/deliver mail to freeport/i) {
 		quest::say("Take this letter to Felisity Starbright. You can find her at the bard guild hall. I'm sure she will compensate you for your trouble.");
 		#:: Give a 18157 - Bardic Letter (Freeport)
-		quest::summonitem(118157);
+		quest::summonitem(18157);
 	}
 }

--- a/feerrott/Innkeep_Gub.pl
+++ b/feerrott/Innkeep_Gub.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/muffin/i) {
 		quest::say("You take dis crate and fill it with muffinz, den seal it up and bring da full crate bak to me. Don't you tink you can go buy dat store stuff either, I wants fresh baked muffinz.  Da store ones too old and will gets moldy too fast, den I have to toss out.  Da make me very unhappy wid you!");
 		#:: Give a 17881 - Muffin Crate
-		quest::summonitem(117881);
+		quest::summonitem(17881);
 	}
 	elsif ($text=~/shipment of bread/i) {
 		quest::say("You go to da south plains and find da Meadowgreen guy.  He is very gud baker and we wantz his bag of bread loaves.  You go tell him dat, get movin!");

--- a/felwithea/Guard_Settine.pl
+++ b/felwithea/Guard_Settine.pl
@@ -7,7 +7,7 @@ sub EVENT_ITEM {
 		#:: Give a large amound of experience
 		quest::exp(30000);
 		#:: Give item 14640 - Silver Amber Ring
-		quest::summonitem(114640);
+		quest::summonitem(14640);
 	}
 	#:: Return unused items
 	plugin::returnUnusedItems();

--- a/felwithea/Tacar_Tissleplay.pl
+++ b/felwithea/Tacar_Tissleplay.pl
@@ -11,6 +11,6 @@ sub EVENT_SAY {
 	if ($text=~/deliver to Kelethin/i) {
 		quest::say("Take this letter to Jakum Webdancer in Kelethin.  You can find him at the bard guild hall.  I am sure he will compensate you for your troubles.");
 		#:: Give a 18161 - A Bardic Letter (Kelethin)
-		quest::summonitem(118161);
+		quest::summonitem(16390);
 	}
 }

--- a/felwithea/Tolon_Nurbyte.pl
+++ b/felwithea/Tolon_Nurbyte.pl
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18841 => 1)) {
 		quest::say("So I see you completed your mission. Good work. You just may be a member of the Silent Watch someday. Well my friend. I will be keeping my eye on you. No doubt we will meet again. Oh, I almost forgot. The Princess wanted you to have this. Now show yourself the door.");
 		#:: Give a 13353 - Thex Dagger
-		quest::summonitem(113353);
+		quest::summonitem(13353);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/felwithea/Tynkale.pl
+++ b/felwithea/Tynkale.pl
@@ -19,12 +19,12 @@ sub EVENT_SAY {
 	if ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give item 51121 - Tradeskill Basics: Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	if ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give item 51122 - Tradeskill Basics: Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 	if ($text=~/service to the clerics of tunare/i) {
 		#:: Match if faction is better than indifferent
@@ -63,7 +63,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18781 => 1)) {
 		quest::say("Greetings. young paladin!  I am Master Tynkale of the Clerics of Tunare.  Here, we shall teach and train you in the skills needed to defeat our evil and diseased enemies.  Take this, our guild tunic - it will help protect you.  Once you are ready to begin your training please make sure that you see Seria Woodwind, she can assist you in experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13591 - Used Gold Training Tunic*
-		quest::summonitem(113591);
+		quest::summonitem(13591);
 		#:: Ding!
 		quest::ding();
 		#:: Give a small amount of xp

--- a/felwithea/Yeolarn_Bronzeleaf.pl
+++ b/felwithea/Yeolarn_Bronzeleaf.pl
@@ -19,12 +19,12 @@ sub EVENT_SAY {
 	if ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give item 51121 - Tradeskill Basics: Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	if ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give item 51122 - Tradeskill Basics: Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 	if ($text=~/protect the Mother/i) {
 		quest::say("Just outside the gates of Felwithe, the forces of Innoruuk gather in the guise of decaying skeletons. Bring me four sets of bone chips as proof of your vigilance. I assure you, your faith shall not go unrewarded.");
@@ -51,7 +51,7 @@ sub EVENT_ITEM {
 		#:: Give a small amount of xp
 		quest::exp(100);
 		#:: Give item 13590 - Faded Gold Training Tunic*
-		quest::summonitem(113590);
+		quest::summonitem(13590);
 		#:: Set faction
 		quest::faction(226,100); 	#:: + Clerics of Tunare
 		quest::faction(279,100); 	#:: + King Tearis Thex
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 		#:: Give a small amount of xp
 		quest::exp(2500);
 		#:: Give item 15014 - Spell: Strike
-		quest::summonitem(115014);
+		quest::summonitem(15014);
 		#:: Set faction
 		quest::faction(226,15); 		#:: + Clerics of Tunare
 		quest::faction(279,15); 	#:: + King Tearis Thex

--- a/felwitheb/Kinool_Goldsinger.pl
+++ b/felwitheb/Kinool_Goldsinger.pl
@@ -35,12 +35,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give item 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give item 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -49,7 +49,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18778 => 1)) {
 		quest::say("Greetings and welcome aboard!  My name's Kinool. Master Enchanter of the Keepers of the Art.  Here is your guild tunic. Make us proud, young pupil! Once you are ready to begin your training please make sure that you see Yuin Starchaser, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13593 - Torn Training Robe*
-		quest::summonitem(113593);
+		quest::summonitem(13593);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/felwitheb/Niola_Impholder.pl
+++ b/felwitheb/Niola_Impholder.pl
@@ -20,12 +20,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give item 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give item 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 }
 
@@ -49,7 +49,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(18777 => 1)) {
 		quest::say("Welcome. I am Niola Impholder. Master Magician of the Keepers of the Art. Here is our guild tunic. Once you are ready to begin your training please make sure that you see Yuin Starchaser, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13592 - Faded Training Robe*
-		quest::summonitem(113592);
+		quest::summonitem(13592);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/felwitheb/Tarker_Blazetoss.pl
+++ b/felwitheb/Tarker_Blazetoss.pl
@@ -20,12 +20,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::emote("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give item 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::emote("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give item 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18779 => 1)) {
 		quest::say("Welcome to the wizards' guild of the Keepers of the Art. My name's Tarker, and I run this guild. You've got a lot of training ahead of you, so let's get started. Here, take this - it's our guild tunic. Wear it with honor, friend. Once you are ready to begin your training please make sure that you see Yuin Starchaser, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13594 - Singed Training Robe*
-		quest::summonitem(113594);
+		quest::summonitem(13594);
 		#:: Ding!
 		quest::ding();
 		#:: Set faction

--- a/freporte/10000.pl
+++ b/freporte/10000.pl
@@ -3,7 +3,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(19930 => 1)) {
 		quest::say("Arg");
 		#:: Give a 19918 - Rough Blue Gem
-		quest::summonitem(119918);
+		quest::summonitem(19918);
 		#:: Ding!
 		quest::ding();
 		#:: Set a timer 'depop' that loops every 5 seconds

--- a/freporte/Brutol_Rhaksen.pl
+++ b/freporte/Brutol_Rhaksen.pl
@@ -5,12 +5,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -19,7 +19,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18857 => 1)) {
 		quest::say("Hahaha... I sure hope you prove more valuable than you look, little one. Once you are ready to begin your training please let me know and I will get you started. I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13561 - Faded Crimson Tunic
-		quest::summonitem(113561);
+		quest::summonitem(13561);
 		#:: Ding!
 		quest::ding();
 		#:: Set faction

--- a/freporte/Elisi_Nasin.pl
+++ b/freporte/Elisi_Nasin.pl
@@ -14,7 +14,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18745 => 1)) {
 		quest::say("Welcome to the Coalition of Tradesfolk underground. We like to keep a low profile around here and not draw any unneeded attention to our operations. you following me? I hope so, for your sake, Anyways, Nestral T'Gaza is in charge with helping out our newest members. Go see her as soon as you get a chance.");
 		#:: Give item 13568 - Brown Faded Tunic
-		quest::summonitem(113568);
+		quest::summonitem(13568);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Fabian.pl
+++ b/freporte/Fabian.pl
@@ -24,7 +24,7 @@ sub EVENT_ITEM {
 #::		if ($random_lute_strings_message == 4) {
 #::			quest::say("Many thanks, merry gentlefolk! Let me cross your palm in gratitude for your kindness. Hmmmm where did my lucky coin go?");
 #::			#:: Give a 13710 - Etched Silver Coin
-#::			quest::summonitem(113710);
+#::			quest::summonitem(13710);
 #::		} else {
 			quest::say("Many thanks, merry gentlefolk! Let me cross your palm in gratitude for your kindness.");
 #:: 		}
@@ -46,7 +46,7 @@ sub EVENT_ITEM {
 #::	if (plugin::takeItems(13710 => 1)) {
 #::		quest::say("'My lucky coin! How did it get in there? Well, never mind that. You are an honest person and although honesty is its own reward, I feel obligated to return the favor. Take this to Dionna if you enjoy music. Farewell friend!");
 #::		#:: Give a 13708 - Note from Fabian
-#::		quest::summonitem(113708);
+#::		quest::summonitem(13708);
 #::		#:: Ding!
 #::		quest::ding();
 #::		#:: Set factions

--- a/freporte/Gregor_Nasin.pl
+++ b/freporte/Gregor_Nasin.pl
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13118 => 1, 13383 => 1, 13952 => 1, 13340 => 1)) {
 		quest::say("Now I have every ingredient mentioned in the Barkeep Compendium. Here. You take it. <..click!.> Whoops!! I just closed it. It's magically sealed, I never closed it before. It's useless to you. I have no need for it any longer. Maybe you can return it to [Clurg] for some type of reward.");
 		#:: Give item 13379 - Barkeep Compendium
-		quest::summonitem(113379);
+		quest::summonitem(13379);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Gren_Frikniller.pl
+++ b/freporte/Gren_Frikniller.pl
@@ -5,7 +5,7 @@ sub EVENT_SAY {
 	elsif ($text=~/sister|falia/i) {
 		quest::say("Ah, my sister Falia has traveled here all the way from Rivervale. I hear that she's been staying up in North Freeport, but I haven't had a chance to find her yet. If you get some spare time, could you take this letter to her for me? Thanks, $name, you're really not so bad after all.");
 		#:: Give a 18925 - Letter to Falia
-		quest::summonitem(118925);
+		quest::summonitem(18925);
 	}
 	elsif ($text=~/rivervale/i) {
 		quest::say("Rivervale?  Well, it's far from here, thank Fizzlethorpe.  They got more wanted posters with my face on 'em than they got trees there.  I mean, 'tweren't my fault either.  Just a friendly game of cards, and this little weasel catches me with an extra ace up my sleeve.  Can you believe this kid calls ol' Grenny here a cheater, right in front of the whole bar?!!  So, you know, I gave him a quick cut, ear to ear, with me dagger...  just to shut him up, you know.  Suddenly, I'm a murderer?  For simply defending myself?! Go figure!");

--- a/freporte/Groflah_Steadirt.pl
+++ b/freporte/Groflah_Steadirt.pl
@@ -21,7 +21,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18818 => 1)) {
 		quest::say("This used to be hanging in Zimel's Blades. It is the price list. It is badly faded though. There was a fire in Zimel's Blades and I was on the scene just afterward. I did not see this hanging. I wonder who took it . . . Hmmmm.. oh, yes.. the markings on the list! It is a code! Here. I will fill it in. Read it. You probably do not even know who [Ariska] is.");
 		#:: Give item 18819 - Tattered Flier
-		quest::summonitem(118819);
+		quest::summonitem(18819);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Harkin_Duskfoot.pl
+++ b/freporte/Harkin_Duskfoot.pl
@@ -17,7 +17,7 @@ sub EVENT_PROXIMITY_SAY {
 	if ($text=~/message/i) {
 		quest::say("Ok, $name, I need you to take this message to Janam in West Freeport. He is usually hanging out in front of the Theater of the Tranquil with that good-for-nothing Rebby. Anyway, give this note to Janam and bring his reply back to me.");
 		#:: Give a 18015 - Note to Janam
-		quest::summonitem(118015);
+		quest::summonitem(18015);
 	}
 }
 

--- a/freporte/Heneva_Jexsped.pl
+++ b/freporte/Heneva_Jexsped.pl
@@ -5,12 +5,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("'I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -19,7 +19,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18855 => 1)) {
 		quest::say("Welcome, friend. I see more than a slight glimmer of hate in your eyes. Good, for we have much work to do. Once you are ready to begin your training please make sure that you see Marv Orilis, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13565 - Old Stained Robe*
-		quest::summonitem(113565);
+		quest::summonitem(13565);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Jheron_Felkis.pl
+++ b/freporte/Jheron_Felkis.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18508 => 1)) {
 		quest::say("So you are from Umvera! What is this? Oh my! Intersting! I'll bind them right away! A little snip here..a little snip there.. All done! That didn't take long, did it? I won't be doing this forever, you know. After the milita burned down my father's home, he could not afford to send me through proper schooling. Ah well, such is life!");
 		#:: Give item 18510 - Pawbook
-		quest::summonitem(118510);
+		quest::summonitem(18510);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a large amount of experience

--- a/freporte/Konious_Eranon.pl
+++ b/freporte/Konious_Eranon.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18856 => 1)) {
 		quest::say("Hey, Nex, we got another sucker.. er.. volunteer, that is, to help us out around here. Here ya go friend, put this on and let's whip you into shape.");
 		#:: Give item 13566 - Blood Spotted Robe*
-		quest::summonitem(113566);
+		quest::summonitem(13566);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Lenka_Stoutheart.pl
+++ b/freporte/Lenka_Stoutheart.pl
@@ -89,7 +89,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13818 => 1)) {
 		quest::say("Oh!! You must work for that Erudite named Palatos. I guess he won't have to spend anymore money drinking in Freeport. Here. Here is the portrait I kept until he could get me a new boat beacon.");
 		#:: Give item 12146 - Ak'anon's Portrait
-		quest::summonitem(112146);
+		quest::summonitem(12146);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Nestral_TGaza.pl
+++ b/freporte/Nestral_TGaza.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/janam and rebby/i) {
 		quest::say("Janam and Rebby are A couple of merchants working the area around the Theater of the Tranquil and the Ashen Order, in West Freeport. It's part of my job to keep tabs on those two rascals. I need someone to take this note to Rebby for me. Don't worry, your efforts won't go unnoticed $name");
 		#:: Give a 18923 - Message to Rebby
-		quest::summonitem(118923);
+		quest::summonitem(18923);
 	}
 }
 

--- a/freporte/Netuk_Phenzon.pl
+++ b/freporte/Netuk_Phenzon.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18818 => 1)) {
 		quest::say("It is about time you returned! Innoruuk would be proud of the red you have spread upon the land.");
 		#:: Give item 15343 - Spell: Siphon Strengh
-		quest::summonitem(115343);
+		quest::summonitem(15343);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Nexvok_Thirod.pl
+++ b/freporte/Nexvok_Thirod.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18854 => 1)) {
 		quest::say("Ah ha.. Fresh meat. here, put this on.. you're one of us now. Do your best to do your worst.");
 		#:: Give item 13564 - Dirty Torn Robe*
-		quest::summonitem(113564);
+		quest::summonitem(13564);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Opal_Darkbriar.pl
+++ b/freporte/Opal_Darkbriar.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18742 => 1)) {
 		quest::say("Welcome to the Guild, here's your guild robe. Now, let's get to work.");
 		#:: Give item 13562 - Dark Stained Robe
-		quest::summonitem(113562);
+		quest::summonitem(13562);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Palatos_Kynarn.pl
+++ b/freporte/Palatos_Kynarn.pl
@@ -18,7 +18,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13817 => 4)) {
 		quest::say("Ahh... I... <Hic!> Need help... <Hic!> You... take this... Go build... boat beacon. <Hic!> Ask gnomes about... <Hic!> boat beacon. They know how... Then bring back... <Hic!> Unnnhh! Prexus help me! I will never drink again.");
 		#:: Give item 12145 - Beacon Mount
-		quest::summonitem(112145);
+		quest::summonitem(12145);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Pietro_Zarn.pl
+++ b/freporte/Pietro_Zarn.pl
@@ -5,12 +5,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics: Volume 1
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics: Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -19,7 +19,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18743 => 1)) {
 		quest::say("A new member to carry the rage of Innoruuk into the city and beyond. How wonderful. I must admit that you do not appear to carry the rage within. Hopefully you shall color the battlefields with the blood of many knights from the Hall of Truth. Here. Wear this tunic with pride. Once you are ready to begin your training please make sure that yo see Gunex Eklar, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13561 - Faded Crimson Tunic
-		quest::summonitem(113561);
+		quest::summonitem(13561);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(18961 => 1)) {
 		quest::say("ou have proven yourself truly evil. Your hatred shall shine from this day forth. Innoruuk commands that I reward you with this. It is called Rage and it serves the powers of hate. Use it to smite the forces of good. Hail Innoruuk!");
 		#:: Give item 12153 - Rage War Maul
-		quest::summonitem(112153);
+		quest::summonitem(12153);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Raltur_Caliskon.pl
+++ b/freporte/Raltur_Caliskon.pl
@@ -36,12 +36,12 @@ sub EVENT_ITEM {
 			#:: Response paraphrased from actual turn-in
 			quest::say("You must collect the other two pieces of the list and take them to a scribe by the name of Rathmana Allin. He can be found in the deserts of South Ro.");
 			#:: Return a 18810 - Bayle List III
-			quest::summonitem(118810);
+			quest::summonitem(18810);
 		}
 		else {
 			quest::say("You have done well. This is the Bayle List. I have heard of it. It is useless without the remaining two parts. Take the list. You must collect the other two pieces of the list and take them to a scribe by the name of Rathmana Allin. He can be found in the deserts of South Ro. First, you must go ask Venox Tarkog what the Bayle List is. He is here in the shrine and will fill you in on your mission.");
 			#:: Give item 18810 - Bayle List III
-			quest::summonitem(118810);
+			quest::summonitem(18810);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a large amount of experience

--- a/freporte/Venox_Tarkog.pl
+++ b/freporte/Venox_Tarkog.pl
@@ -18,7 +18,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18744 => 1)) {
 		quest::say("Here we find a new follower.. Here we find a tunic of the Dismal Rage. Put the two together and let the hate grow. Let it be known from now on that your soul belongs to the Prince of Hate, Innoruuk. It is his power which flows within you. Destroy all those who oppose us. Please introduce your hate to the others in this shrine.");
 		#:: Give item 13561 - Faded Crimson Tunic
-		quest::summonitem(113561);
+		quest::summonitem(13561);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Xelha_Nevagon.pl
+++ b/freporte/Xelha_Nevagon.pl
@@ -20,7 +20,7 @@ sub EVENT_ITEM {
 		if ($faction <= 5) {
 			quest::say("Let's see here. One.. two.. three.. and.. four. Great!! Just enough for my needs. You are serving Xelha well. I give you Xelha's Sparkler. It is not much, but neither are you. You know what I really need is a cyclops eye. That would be worthy of a great reward.");
 			#:: Give item 12247 - Xelha's Sparkler
-			quest::summonitem(112247);
+			quest::summonitem(12247);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -38,10 +38,10 @@ sub EVENT_ITEM {
 			#:: Made up
 			quest::say("You are no ally of the Dismal Rage.  Run while you still have legs!!");
 			#:: Return four 13099 - Spiderling Silk
-			quest::summonitem(113099);
-			quest::summonitem(113099);
-			quest::summonitem(113099);
-			quest::summonitem(113099);
+			quest::summonitem(13099);
+			quest::summonitem(13099);
+			quest::summonitem(13099);
+			quest::summonitem(13099);
 		}
 	}
 	#:: Match four 10307 - Fire Beetle Eye
@@ -68,10 +68,10 @@ sub EVENT_ITEM {
 			#:: Made up
 			quest::say("You are no ally of the Dismal Rage.  Run while you still have legs!!");
 			#:: Return four 10307 - Fire Beetle Eye
-			quest::summonitem(110307);
-			quest::summonitem(110307);
-			quest::summonitem(110307);
-			quest::summonitem(110307);
+			quest::summonitem(10307);
+			quest::summonitem(10307);
+			quest::summonitem(10307);
+			quest::summonitem(10307);
 		}
 	}
 	#:: Match four 13073 - Bone Chips
@@ -96,10 +96,10 @@ sub EVENT_ITEM {
 			#:: Made up
 			quest::say("You are no ally of the Dismal Rage.  Run while you still have legs!!");
 			#:: Return four 13073 - Bone Chips
-			quest::summonitem(113073);
-			quest::summonitem(113073);
-			quest::summonitem(113073);
-			quest::summonitem(113073);
+			quest::summonitem(13073);
+			quest::summonitem(13073);
+			quest::summonitem(13073);
+			quest::summonitem(13073);
 		}	
 	}
 	#:: Match a 13927 - Cyclops Eye
@@ -123,7 +123,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("I will do nothing to aid beings like you.");
 			#:: Return a 13927 - Cyclops Eye
-			quest::summonitem(113927);
+			quest::summonitem(13927);
 		}
 	}
 	#:: Return unused items

--- a/freporte/Zenita_D-Rin.pl
+++ b/freporte/Zenita_D-Rin.pl
@@ -19,7 +19,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(22298 => 1)) {
 		quest::say("Why I will be.. You got it!! I thought I took it out of the deck. Very well. You win the Spare Lens fair and square. Here you are. Now get out of my sight.");
 		#:: Give item 13279 - Telescope Lens (Phiz's Lens)
-		quest::summonitem(113279);
+		quest::summonitem(13279);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/freportn/Caskin_Marsheart.pl
+++ b/freportn/Caskin_Marsheart.pl
@@ -14,12 +14,12 @@ sub EVENT_SAY {
 	if ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the  [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Tradeskills Volume I 
-		quest::summonitem(151121); 
+		quest::summonitem(51121); 
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Tradeskills Volume II 
-		quest::summonitem(151122); 
+		quest::summonitem(51122); 
 	}
 } 
 
@@ -28,7 +28,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18747 => 1 )) {
 		quest::say("Welcome to the guild. here's your guild tunic. Once you are ready to begin your training please make sure that you see Sten Harnak, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13571 - Colorfully Patched Tunic*
-		quest::summonitem(113571);
+		quest::summonitem(13571);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Celsar_Vestagon.pl
+++ b/freportn/Celsar_Vestagon.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/eradicate the piranha/i) {
 		quest::say("Yes. You are new to the word of Marr. Go to the waters surrounding the Hall of Truth. Fill this sack with no fewer than four dead piranha. You'd best keep well fed. I do not want you to eat the fish before you fill the sack and combine it. May Marr be with you.");
 		#:: Give a 17936 - Empty Fish Sack
-		quest::summonitem(117936); 
+		quest::summonitem(17936); 
 	}
 }
 

--- a/freportn/Eestyana_Naestra.pl
+++ b/freportn/Eestyana_Naestra.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18735 => 1)) {
 		quest::say("The Truthbringer welcomes you into his life. Here is the tunic of Marr. Wear it with pride and be sure to conduct yourself with valor. Once you are ready to begin your training please make sure that you see Salinsa Delfdosan, she can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks.");
 		#:: Give a 13554 - Faded Purple Tunic*
-		quest::summonitem(113554);
+		quest::summonitem(13554);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Falia_Frikniller.pl
+++ b/freportn/Falia_Frikniller.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18925 => 1)) {
 		quest::say("Heh, that good for nothing fool. I've been here for over a month already, and I haven't seen him yet. Bah, anyway, could you take this back to him for me? It was our grandfather's lucky necklace. He passed it down to our father, and now onto my brother. Knowing that little worm, Grenny, he'll probably trade it for a mug of ale. Oh well, thanks for delivering the letter, friend. Good day to you, and safe travels.");
 		#:: Give item 13159 - Broken Heirloom Necklace
-		quest::summonitem(113159);
+		quest::summonitem(13159);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/freportn/Groflah_Steadirt.pl
+++ b/freportn/Groflah_Steadirt.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18818 => 1 )) {
 		quest::say("Where did you find this? This was the main price list of Zimel's Blades, but it should be all burnt up. I was at Zimel's right after the fire and I did not see it hanging where it should have been. The entire inside was gutted and . . . wait . . . the sequence of the dots!! Hmmm. I cannot talk with you here. Meet me at the Seafarer's by the docks at night. Give me the note when next we meet.");
 		#:: Give item 18818 - a tattered flier
-		quest::summonitem(118818);
+		quest::summonitem(18818);
 	}
 	#:: Turn in for 13919 Reward Raw Short Sword
 	if (plugin::takeItems(13919 => 1)) {

--- a/freportn/Gygus_Remnara.pl
+++ b/freportn/Gygus_Remnara.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18738 => 1 )) {
 		quest::say("Welcome to the Sentries of Passion. We are the protectors of the Temple of Marr. Wear our tunic with pride, young knight! Find your wisdom within these walls and in the words of our priests. And remember to aid all who follow the twin deities, Mithaniel and Erollisi Marr.");
 		#:: Give item 13556 - White and Blue Tunic*
-		quest::summonitem(113556);
+		quest::summonitem(13556);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Kalatrina_Plossen.pl
+++ b/freportn/Kalatrina_Plossen.pl
@@ -10,7 +10,7 @@ sub EVENT_SAY {
 		if ($faction < 5) {	
 		quest::say("Stand tall then, knight! We have need of your services. We have sent a man to infiltrate the militia. We fear he may soon be found out. Take him this note of warning. Say the words, 'Truth is good,' and you shall find him. Be careful, young knight. The militia does not take prisoners.");
 		#:: Summon 18817 - A Sealed Letter (To Alayle)
-		quest::summonitem(118817);
+		quest::summonitem(18817);
 		}
 		else {
 			quest::say("Work on the ways of valor before we discuss such things. You are on the righteous path of the Truthbringer, but there is more work to do.");
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 		#:: Ding!
 		quest::ding();
 		#:: Give item 18818 - a tattered flier
-		quest::summonitem(118818);
+		quest::summonitem(18818);
 		#:: Set faction
 		quest::faction(281,1); 	#:: + Knights of Truth
 		quest::faction(271,-1); #:: - Dismal Rage

--- a/freportn/Merko_Quetalis.pl
+++ b/freportn/Merko_Quetalis.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 	elsif ($text=~/small task/i) {
 		quest::say("Venture to the Commonlands and seek out our noble friend Altunic Jartin. He lives and works out of his home. Hand him this note.");
 		#:: Summon 18896 - A Note (Note to Altunic)
-		quest::summonitem(118896);		
+		quest::summonitem(18896);		
 	}
 	elsif ($text=~/token of generosity/i) {
 		quest::say("Go to the deserts of North Ro. Seek out the desert tarantulas. Stand and face this dreaded creature. If you are lucky, you will find a venom sac. This is what I require. When you return, hand it to me.");
@@ -29,7 +29,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(14018 => 1 )) {
 		quest::say("You have earned the token of bravery. Now you must ask yourself if you are ready to face true fear. You will have but one chance. If you feel you are powerful enough to easily slay that desert tarantula, then hand me both tokens earned and you shall face the Test of Truth.");
 		#:: Give item 12144 - Token of Bravery
-		quest::summonitem(112144);
+		quest::summonitem(12144);
 		#:: Give a small amount of xp
 		quest::exp(100);
 		#:: Ding!
@@ -61,7 +61,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13866 => 1)) {
 		quest::say("You have performed well. You have shown your allegiance to truth and cast aside the Freeport Militia. The militia will surely despise you from now on. This is how they treat the Knights of Truth. Beware. The followers of Marr stand alone in this city.");
 		#:: Give item 18828 - Testimony
-		quest::summonitem(118828);
+		quest::summonitem(18828);
 		#:: Give a small amount of xp
 		quest::exp(100);
 		#:: Ding!

--- a/freportn/Sentry_Andlin.pl
+++ b/freportn/Sentry_Andlin.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12127 => 1 )) {
 		quest::say("My thanks to you. I feel much strength. You may take the bottle to the next sentry.");
 		#:: Give item 12128 - Part of Potion of Marr
-		quest::summonitem(112128);
+		quest::summonitem(12128);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Sentry_Boris.pl
+++ b/freportn/Sentry_Boris.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12128 => 1 )) {
 		quest::say("Ahhh!! That has given me back lost energy. Thank you. Please take this to the next sentry.");
 		#:: Give item 12129 - Part of Potion of Marr
-		quest::summonitem(112129);
+		quest::summonitem(12129);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Sentry_Gallius.pl
+++ b/freportn/Sentry_Gallius.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12129 => 1 )) {
 		quest::say("Excellent!! I feel quite refreshed with but a sip. You may take this to the next sentry.");
 		#:: Give item 12130 - Part of Potion of Marr
-		quest::summonitem(112130);
+		quest::summonitem(12130);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Sentry_Janeal.pl
+++ b/freportn/Sentry_Janeal.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12130 => 1 )) {
 		quest::say("I feel quite alert now. Thank you. You should take this to the next sentry.");
 		#:: Give item 12131 - Half of Potion of Marr
-		quest::summonitem(112131);
+		quest::summonitem(12131);
 		#:: Ding!
 		quest::ding();
 		#:: Set faction

--- a/freportn/Sentry_Meighan.pl
+++ b/freportn/Sentry_Meighan.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12131 => 1 )) {
 		quest::say("Very good. Nothing more than a sip and I feel much more alert. The next sentry awaits you.");
 		#:: Give item 12132 - Part of Potion of Marr
-		quest::summonitem(112132);
+		quest::summonitem(12132);
 		#:: Ding!
 		quest::ding();
 		#:: Set faction

--- a/freportn/Sentry_Theo.pl
+++ b/freportn/Sentry_Theo.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12132 => 1 )) {
 		quest::say("That gives me new life. Take it to the next sentry.");
 		#:: Give item 12133 - Part of Potion of Marr
-		quest::summonitem(112133);
+		quest::summonitem(12133);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Sentry_Warren.pl
+++ b/freportn/Sentry_Warren.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12133 => 1 )) {
 		quest::say("Thank you. I believe you need to seek out Sentry Xyrin. She is not at the temple. I believe she left to speak with [Sisterhood of Erollisi]. She was to speak with Styria.");
 		#:: Give item 12134 - Last of Potion of Marr
-		quest::summonitem(112134);
+		quest::summonitem(12134);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Serna_Tasknon.pl
+++ b/freportn/Serna_Tasknon.pl
@@ -10,7 +10,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("Good. Take this Potion of Marr to the Sentries of Passion. They are the protectors of this temple. Start in alphabetical order and the first shall take but a sip then you shall take it to the next in order of the alphabet. There are but eight sentries. Sentry Andlin to Sentry Xyrin. Go.");
 			#:: Summon 12127 - Full Potion of Marr
-			quest::summonitem(112127);
+			quest::summonitem(12127);
 		}
 		else {
 			quest::say("The path you walk is correct, but you have further to travel before you need worry about this.");
@@ -23,7 +23,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItemsCoin(0,0,10,0, 12126 => 3)) {
 		quest::say("I thank you for your ten gold coins. Now we can pay the weekly oxygen tax imposed by the militia. Here is the shark powder.");
 		#:: Give item 12125 - shark Powder
-		quest::summonitem(112125);
+		quest::summonitem(12125);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -49,7 +49,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(12135 => 1 )) {
 		quest::say("The Sentries of Passion informed me of your journey to the Ocean of Tears and the demise of Sentry Xyrin. You performed beyond the call of duty. This is what makes an exceptional person. Take this for your great deed. The twin deities would wish it so.");
 		#:: Give item 15207 - Spell: Divine Aura
-		quest::summonitem(115207);
+		quest::summonitem(15207);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Theron_Rolius.pl
+++ b/freportn/Theron_Rolius.pl
@@ -23,7 +23,7 @@ sub EVENT_SAY {
 	elsif ($text=~/hunt/i) {
 		quest::say("I thought I spied the shoulders of a swimmer upon you! Take this large sack. Travel to the Ocean of Tears. There are numerous reef sharks there. I shall require no fewer than two shark skins. When the full sack is combined and returned to me, I shall reward you.");
 		#:: Summon 17937 - Empty Shark Sack
-		quest::summonitem(117937);
+		quest::summonitem(17937);
 	}
 }
 
@@ -50,7 +50,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13873 => 1)) {
 		quest::say("Fantastic work, my young knight. Here is a small token of my appreciation -- a fine Sharkskin Shield. It should serve you well in battle.");
 		#:: Give a 13868 - Sharkskin Shield
-		quest::summonitem(113868);
+		quest::summonitem(13868);
 		#:: Ding!
 		quest::ding();
 		#:: Confirmed no faction reward

--- a/freportn/Tholius_Quey.pl
+++ b/freportn/Tholius_Quey.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18735 => 1 )) {
 		quest::say("Welcome to the Priests of Marr. Here, you will be taught how powerful passion truly is. The passion of Erollisi Marr, the Queen of Love, shall flow through you and into all those you meet. Wear this tunic in the name of Love.");
 		#:: Give a 13556 - White and Blue Tunic*
-		quest::summonitem(113556);
+		quest::summonitem(13556);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18736 => 1 )) {
 		quest::say("Welcome to the Priests of Marr. Here, you will be taught how powerful passion truly is. The passion of Erollisi Marr, the Queen of Love, shall flow through you and into all those you meet. Wear this tunic in the name of Love.");
 		#:: Give a 13556 - White and Blue Tunic*
-		quest::summonitem(113556);
+		quest::summonitem(13556);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Ton_Twostring.pl
+++ b/freportn/Ton_Twostring.pl
@@ -18,17 +18,17 @@ sub EVENT_SAY {
 	elsif ($text=~/kelethin/i) {
 		quest::say("Take this pouch to Idia in Kelethin.  You can find her at the bard guild hall.  I am sure she will compensate you for your troubles.");
 		#:: Summon 18167 - Pouch of Mail (Kelethin)
-		quest::summonitem(118167);
+		quest::summonitem(18167);
 	}
 	elsif ($text=~/qeynos/i) {
 		quest::say("Take this pouch to Eve Marsinger in Qeynos.  You can find her at the bard guild hall.  I am sure she will compensate you for your troubles.");
 		#:: Summon 18165 - Pouch of Mail (Highpass)
-		quest::summonitem(118165);
+		quest::summonitem(18165);
 	}
 	elsif ($text=~/highpass/i) {
 		quest::say("Take this pouch to Lislia Goldtune in Highpass.  You can find her at the entrance to HighKeep.  I am sure she will compensate you for your troubles.");
 		#:: Summon 18156 - Pouch of Mail (Qeynos)
-		quest::summonitem(118156);
+		quest::summonitem(18156);
 	}
 }
 

--- a/freportn/Valeron_Dushire.pl
+++ b/freportn/Valeron_Dushire.pl
@@ -21,7 +21,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18737 => 1 )) {
 		quest::say("Welcome to the Guild, here's your guild tunic. Now, let's get to work.");
 		#:: Give item 13554 - Faded Purple Tunic*
-		quest::summonitem(113554);
+		quest::summonitem(13554);
 		#:: Ding!
 		quest::ding();
 		#:: Give a small amount of experience
@@ -37,7 +37,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18827 => 1 )) {
 		quest::say("Praise be to Marr!! You have done the impossible!! Sir Lucan is finally sent to the higher courts of the Tribunal. The city now has a chance to prosper. The Hall of Truth has been redeemed and gives you thanks. Take this, it is the Sword of Faith. May you wield it with righteousness. Beware of the remainder of the militia. They will be hunting for your head.");
 		#:: Give item 13947 - Brilliant Sword of Faith
-		quest::summonitem(113947);
+		quest::summonitem(13947);
 		#:: Ding!
 		quest::ding();
 		#:: Give a small amount of experience

--- a/freportw/Cain_Darkmoore.pl
+++ b/freportw/Cain_Darkmoore.pl
@@ -42,13 +42,13 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13916 => 1 )) {
 		quest::say("I must have two Deathfist belts.");
 		#:: Return a 13916 - Deathfist Slashed Belt
-		quest::summonitem(113916);
+		quest::summonitem(13916);
 	}
 	#:: Match a 18742 - A Tattered Note
 	elsif (plugin::takeItems(18742 => 1 )) {
 		quest::say("Welcome to the Steel Warriors, young warrior. It is time to prove your mettle. Look to the outskirts of Freeport and join the fray. Show Clan Deathfist what a warrior of the bunker can do.");
 		#:: Give item 13572 - Dirty Training Tunic
-		quest::summonitem(113572);		
+		quest::summonitem(13572);		
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Guard_Alayle.pl
+++ b/freportw/Guard_Alayle.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 		if ($class eq "Paladin") {
 			quest::say("This is not good news. I must leave immediately. Here. Take this to Kala.. I mean my father. I found it on the floor of Sir Lucan D'Lere's quarters. Thanks again, messenger. I got this just in time");
 			#:: Give a 18818 - A Tattered Flier
-			quest::summonitem(118818);
+			quest::summonitem(18818);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions

--- a/freportw/Hyrill_Pon.pl
+++ b/freportw/Hyrill_Pon.pl
@@ -36,7 +36,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13987 => 1)) {
 		quest::say("You found it!? My sap of a brother was right after all! I sure don't want that thing. It sends shivers down my spine just holding it. Here. Take it!");
 		#:: Give a 13988 - Jeweled Skull
-		quest::summonitem(113988);
+		quest::summonitem(13988);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Janam_Rekish.pl
+++ b/freportw/Janam_Rekish.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 18015 => 1)) {
 		quest::emote("scribbles out a note and says, 'Please make sure that Harkin gets this right away. If you lose it, it could mean both of our heads.'");
 		#:: Give item 18016 - Note to Harkan
-		quest::summonitem(118016);
+		quest::summonitem(18016);
 		#:: Give a small amount of xp
 		quest::exp(500);
 		#:: Ding!

--- a/freportw/Larn_Brugal.pl
+++ b/freportw/Larn_Brugal.pl
@@ -13,7 +13,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("We would be most thankful for your service. Please take this voucher over to Groflah at Groflahs Forge in North Freeport. He will give you the shipment of weapons.");
 			#:: Give item 18820 - Sealed Letter
-			quest::summonitem(118820);
+			quest::summonitem(18820);
 		}
 		else {
 			quest::say("Only a warrior would be capable of this service, but thanks for offering.");
@@ -26,7 +26,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12241 => 1, 12242 => 1, 12243 => 1, 12244 => 1)) {
 		quest::say("Good work, $name. The bunker shall be well stocked. Here you are, my friend. Take this raw blade. You can take it to Groflah - he will sharpen and polish it for you. It should be a formidable weapon.");
 		#:: Give a 13919 - Reward Raw Short Sword
-		quest::summonitem(113919);
+		quest::summonitem(13919);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Linadian.pl
+++ b/freportw/Linadian.pl
@@ -20,7 +20,7 @@ sub EVENT_ITEM {
 		#:: Ding!
 		quest::ding();
 		#:: Give a 12187 - Banded Orc Vest
-		quest::summonitem(112187);
+		quest::summonitem(12187);
 		#:: Set factions
 		quest::faction(276, 1);	 		#:: + Kelethin Merchants
 		quest::faction(246, 1); 		#:: + Faydark's Champions
@@ -35,7 +35,7 @@ sub EVENT_ITEM {
 		#:: Ding!
 		quest::ding();
 		#:: Give a 12187 - Banded Orc Vest
-		quest::summonitem(112187);
+		quest::summonitem(12187);
 		#:: Set factions
 		quest::faction(276, 1);	 		#:: + Kelethin Merchants
 		quest::faction(246, 1); 		#:: + Faydark's Champions

--- a/freportw/Lorme_Tredore.pl
+++ b/freportw/Lorme_Tredore.pl
@@ -3,7 +3,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18740 => 1)) {
 		quest::say("Welcome to the Academy of Arcane Sciences. I am Lorme Tredore, Master Magician. Here is our guild robe, wear it with pride and represent us well, young $name. Now, let's get to work.");
 		#:: Give a 13559 - Used Violet Robe*
-		quest::summonitem(113559);
+		quest::summonitem(13559);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Opal_Darkbriar.pl
+++ b/freportw/Opal_Darkbriar.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18739 => 1)) {
 		quest::say("Welcome to the Academy of Arcane Sciences. Here's one of our guild robes for you to wear. Now, let's get to work.");
 		#:: Give a 13558 - Patched Violet Robe
-		quest::summonitem(113558);
+		quest::summonitem(13558);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Palon_Deskeb.pl
+++ b/freportw/Palon_Deskeb.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/get the minnow/i) {
 		quest::say("Please try. Here you are. Take this jar. Offer the jar to the minnows. Maybe they will swim into it.");
 		#:: Give item 13861 - Jar of Liquid
-		quest::summonitem(113861);
+		quest::summonitem(13861);
 	}
 }
 

--- a/freportw/Ping_Fuzzlecutter.pl
+++ b/freportw/Ping_Fuzzlecutter.pl
@@ -5,7 +5,7 @@ sub EVENT_SAY {
 	if ($text=~/components/i) {
 		quest::say("I require a diamond, a star ruby, a pearl, a [special fire emerald], a sapphire, a fire opal, and two enchanted platinum bars. Take this bag and combine the items once you have them all and bring it back to me.");
 		#:: Give item 17512 - Empty Gem Bag
-		quest::summonitem(117512);
+		quest::summonitem(17512);
 	}
 	if ($text=~/special fire emerald/i) {
 		quest::say("Now the fire emerald I want is not the normal one you receive from most jewelers. There is one jeweler I know who has the special one I want. Last time I heard, she had traveled to the elven outpost. Just ask her about special fire emeralds.");
@@ -29,13 +29,13 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(6710 => 1 )) {
 		quest::emote("smiles broadly as he rifles through the bag, then looks up at you and says, 'Bout time! Here is the coffin as promised.'");
 		#:: Give item 17080 - Gem Encrusted Casket
-		quest::summonitem(117080);
+		quest::summonitem(17080);
 	}
 	#:: Turn in for Clumps of Hair ID- 12335 - Lock of Hair ID- 12338 - Tattered Toupee ID- 12337
 	if (plugin::takeItems(12335 => 2, 12338 =>1, 12337 =>1)) {
 		quest::say("You are a good helper. Here you go. One genuine, charismatic, lady magnet, zero to hero making Mane Attraction!! Guaranteed to lower prices world wide. Guaranteed to last forever.. Err.. Well,.. It has a 1000 year warranty at least.");
 		#:: Give item 12254 - Mane Attraction
-		quest::summonitem(112254);
+		quest::summonitem(12254);
 		#:: Give a small amount of xp
 		quest::exp(500);
 		#:: Ding!

--- a/freportw/Plagus_Ladeson.pl
+++ b/freportw/Plagus_Ladeson.pl
@@ -67,7 +67,7 @@ sub EVENT_SAY {
 	elsif ($text=~/milea is in east karana/i) {
 		quest::say("You have seen Milea Clothspinner!! This is great news. I wish I could travel to see her, but Cain will not allow me to do so at this time. You must take her a note for me. Here, take this to her. As a master in this order, I command you to do so immediately. Go!!");
 		#:: Give a 18934 - A Sealed Letter "LoveToMilea"
-		quest::summonitem(118934);
+		quest::summonitem(18934);
 	}
 }
 

--- a/freportw/Puab_Closk.pl
+++ b/freportw/Puab_Closk.pl
@@ -25,7 +25,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("Then you shall aid our family. My former pupil [skilled monk of the Clawfist] has been banished by his people. You will go to him and hand him this token as proof of your origin. He shall be expecting you.");
 			#:: Give a 12369 - Puab's Token
-			quest::summonitem(112369);
+			quest::summonitem(12369);
 		}
 	}
 } 
@@ -35,7 +35,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18746 => 1 )) {
 		quest::say("Oh my! Opal? She is providing these agents of Neriak with information regarding the Acedemy's secrets. I can not tell Cain about this. He will be furious. Show this to Toala. She will know what to do.");
 		#:: Give a 13507 - Torn Cloth Tunic
-		quest::summonitem(113507);
+		quest::summonitem(13507);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -49,7 +49,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(28055 => 1 )) {
 		quest::say("You have performed a great service to one who is your brother. Your loyalty shines brightly, as does your skill. Take the treant fists. They are yours now.");
 		#:: Give a 12344 - Treant Fists
-		quest::summonitem(112344);
+		quest::summonitem(12344);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Rebby_Willend.pl
+++ b/freportw/Rebby_Willend.pl
@@ -8,7 +8,7 @@ sub EVENT_ITEM {
 	#:: Turn in for 18923 - Message to Rebby
 	if (plugin::check_handin(\%itemcount, 18923 => 1)) {
 		#:: Give item 13158 - Rebbys Rat Whiskers
-		quest::summonitem(113158);
+		quest::summonitem(13158);
 		#:: Give a small amount of xp
 		quest::exp(50);
 		#:: Ding!

--- a/freportw/Reyia_Beslin.pl
+++ b/freportw/Reyia_Beslin.pl
@@ -36,7 +36,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(10400 => 1, 1903 => 1, 2299 => 1, 10131 => 1)) {
 		quest::say("You have proven yourself a mighty warrior. I am honored to present you, $name, with the orange Sash of Order.");
 		#:: Give item 10132 - Sash of Order
-		quest::summonitem(110132);
+		quest::summonitem(10132);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -50,7 +50,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13237 => 1, 13238 => 1, 10132 => 1)) {
 		quest::say("$name, Congratulations. With the destruction of these evil items, the wand of the Burning Dead will never bring harm to anyone on Norrath again. It is my honor to present to you, on behalf of Master Closk and the Ashen Order, the red sash. May Quellious be with you always.You have proven yourself a mighty warrior. I am honored to present you, $name, with the Red Sash of Order.");
 		#:: Give item 10133 - Red Sash of Order
-		quest::summonitem(110133);
+		quest::summonitem(10133);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Romiak_Jusathorn.pl
+++ b/freportw/Romiak_Jusathorn.pl
@@ -3,7 +3,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18741 => 1 )) {
 		quest::say("Greetings, I am Romiak Jusathorn, Master Enchanter of the Academy. Take this.. it's our guild robe; it will help protect you in this harsh environment. Now, let's get to work!");
 		#:: Give item 13560 - Old Violet Robe
-		quest::summonitem(113560);
+		quest::summonitem(13560);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Swin_Blackeye.pl
+++ b/freportw/Swin_Blackeye.pl
@@ -19,7 +19,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12147 => 1 )) {
 		quest::say("Here you go then.");
 		#:: Give a 18814 - Sealed Letter
-		quest::summonitem(118814); 
+		quest::summonitem(18814); 
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Tara_Neklene.pl
+++ b/freportw/Tara_Neklene.pl
@@ -68,12 +68,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("The word of mouth in the Academy of Arcane Science is that you are no foe, but you have yet to prove your worth to us. Perform more tasks for the great Tara Neklene.");
 			#:: Return a 13225 - Illegible Scroll
-			quest::summonitem(113225);
+			quest::summonitem(13225);
 		}
 		else {
 			quest::say("You had best leave my sight. I am a faithful member of the Academy of Arcane Science and you are no ally of ours.");
 			#:: Return a 13225 - Illegible Scroll
-			quest::summonitem(113225);
+			quest::summonitem(13225);
 		}
 	}
 	#:: Return unused items

--- a/freportw/Toala_Nehron.pl
+++ b/freportw/Toala_Nehron.pl
@@ -18,7 +18,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Why, that little trollop! What is she up to? Cain will never believe this! She must be in league with some faction of the dark elves, but why? Neither the Academy of Arcane Science nor Cain will believe this note. I will see what I can do. As for you, I command you to kill this Shintl and her dark elf courier Hollish!! Put their heads into this box and combine them. We shall cut the link. Bring me thier heads.");
 			#:: Give a 17971 - Toala's Box for heads
-			quest::summonitem(117971);
+			quest::summonitem(17971);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -28,12 +28,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("The Steel Warriors have no cause to dislike you, but you have yet to prove your worth to this guild.");
 			#:: Return a 18814 - Sealed Letter
-			quest::summonitem(118814);
+			quest::summonitem(18814);
 		}
 		else {	
 			quest::say("Your head shall look grand mounted on the wall of the Steel Warriors Arena!!");
 			#:: Return a 18814 - Sealed Letter
-			quest::summonitem(118814);
+			quest::summonitem(18814);
 		}
 	}
 	#:: Match a 12246 - Box with Two heads
@@ -60,12 +60,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("The Steel Warriors have no cause to dislike you, but you have yet to prove your worth to this guild.");
 			#:: Return a 12246 - Box with Two heads
-			quest::summonitem(112246);
+			quest::summonitem(12246);
 		}
 		else {	
 			quest::say("Your head shall look grand mounted on the wall of the Steel Warriors Arena!!");
 			#:: Return a 12246 - Box with Two heads
-			quest::summonitem(112246);
+			quest::summonitem(12246);
 		}
 	}
 	#:: Return unused items

--- a/freportw/Toxdil.pl
+++ b/freportw/Toxdil.pl
@@ -16,7 +16,7 @@ sub EVENT_ITEM {
 		if (plugin::takeItems(12353 => 1)) {
 			quest::say("The gem!! I would notice it's sparkle anywhere!! I cannot believe you are handing it back to me!! What a fool. Here you are fool. You can have this worthless key now.");
 			#:: Give a 12351 - A Tiny Key
-			quest::summonitem(112351);
+			quest::summonitem(12351);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a large amount of experience
@@ -26,7 +26,7 @@ sub EVENT_ITEM {
 		elsif (plugin::takeItemsCoin(0, 0, 20, 0, 14017 => 2)) {
 			quest::say("Here is your snake venom. May you... shall we say... apply it to good use.");
 			#:: Give item 14016 - Snake venom
-			quest::summonitem(114016);
+			quest::summonitem(14016);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a small amount of experience
@@ -36,14 +36,14 @@ sub EVENT_ITEM {
 		elsif (plugin::takeItemsCoin(0, 0, 20, 0, 14017 => 2)) {
 			quest::say("I require two snake venom sacs and my fee of 20 gold coins before I shall create the snake venom");
 			#:: Return a 14017 - Snake Venom Sac
-			quest::summonitem(114017);
+			quest::summonitem(14017);
 		}
 		#:: Match two 14017 - Snake Venom Sac
 		elsif (plugin::takeItems(14017 => 2)) {
 			quest::say("I require two snake venom sacs and my fee of 20 gold coins before I shall create the snake venom");
 			#:: Return two 14017 - Snake Venom Sac
-			quest::summonitem(114017);
-			quest::summonitem(114017);
+			quest::summonitem(14017);
+			quest::summonitem(14017);
 		}
 		#:: Return unused items
 		plugin::returnUnusedItems();

--- a/freportw/Velan_Torresk.pl
+++ b/freportw/Velan_Torresk.pl
@@ -36,7 +36,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Good work, $name, you've worked hard and proven yourself a valuable addition to the Ashen Order. Here's your white sash, wear it with pride.");
 			#:: Give a 10130 - White Training Sash
-			quest::summonitem(110130);
+			quest::summonitem(10130);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -49,10 +49,10 @@ sub EVENT_ITEM {
 		else {
 			quest::say("I have been watching you, and appreciate the help you've given to the brothers and sisters of the Ashen Order, but I feel that such a vital matter should be left to one of our more trusted members.");
 			#:: Return two 13794 - Deathfist Pawn Scalp, a 13067 - Snake Fang, and a 13073 - Bone Chips
-			quest::summonitem(113794);
-			quest::summonitem(113794);
-			quest::summonitem(113067);
-			quest::summonitem(113073);
+			quest::summonitem(13794);
+			quest::summonitem(13794);
+			quest::summonitem(13067);
+			quest::summonitem(13073);
 		}
 			
 	}
@@ -62,7 +62,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Ah, well done, $name. You have proven that you are a very skillful fighter and it is a honor to have you as a member of the Ashen Order. On behalf of Master Closk, and under the watchful eyes of Quellious, I present you, $name, with this, the yellow Sash of Order. Go out and make us proud.");
 			#:: Give a 10131 - Yellow Sash of Order
-			quest::summonitem(110131);
+			quest::summonitem(10131);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -75,10 +75,10 @@ sub EVENT_ITEM {
 		else {
 			quest::say("I have been watching you, and appreciate the help you've given to the brothers and sisters of the Ashen Order, but I feel that such a vital matter should be left to one of our more trusted members.");
 			#:: Return a 10130 - White Training Sash, a 13058 - Giant Snake Rattle, a 13916 - Deathfist Slashed Belt, and a 20901 - Desert Tarantula Chitin
-			quest::summonitem(110130);
-			quest::summonitem(113058);
-			quest::summonitem(113916);
-			quest::summonitem(120901);
+			quest::summonitem(10130);
+			quest::summonitem(13058);
+			quest::summonitem(13916);
+			quest::summonitem(20901);
 		}
 	}
 	#:: Return unused items

--- a/freportw/a_prisoner.pl
+++ b/freportw/a_prisoner.pl
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12196 => 1, 16581 => 1, 13498 => 1)) {
 		quest::say("Hide, hide, safe, cee.. lerk has the clue.. Must travel.. Travel.. Travel.. Tunaria's corridor.");
 		#:: Give a 12143 - H.K. 102
-		quest::summonitem(112143);
+		quest::summonitem(12143);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/peasant_woman.pl
+++ b/freportw/peasant_woman.pl
@@ -13,7 +13,7 @@ sub EVENT_SAY {
 		if ($class== 3) {
 			quest::say("Surely you are a pure soul. If you would take this bucket of water to my brother, I would be forever grateful. I am just so tired, I need to rest... She slumps to the floor and begins to breathe shallowly, in short, harsh gasps.");
 			#:: Give item 29008 - Bucket of Water
-			quest::summonitem(129008);
+			quest::summonitem(29008);
 		}
 	}
 }

--- a/gfaydark/Expin.pl
+++ b/gfaydark/Expin.pl
@@ -42,7 +42,7 @@ sub EVENT_ITEM {
 	} 
 	if(plugin::check_handin(\%itemcount, 16390 => 1)) {#Crumpled Piece of Paper
 		quest::say("Ahhh! You found it! Here let me make you a copy and put this in a secure spot so I don't lose it again.");
-		quest::summonitem(24098);#Remiss Sketch
+		quest::summonitem(16390);#Remiss Sketch
 		quest::exp(5061818);#This is 2% of level 53 xp.
 	}
   	#do all other handins first with plugin, then let it do disciplines

--- a/global/Priest_of_Discord.pl
+++ b/global/Priest_of_Discord.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/read/i) {
 		quest::say("Very well. Here you go. Simply return it to me to be released from the chains of Order.");
 		#:: Summon a 18700 - Tome of Order and Discord
-		quest::summonitem(118700);
+		quest::summonitem(18700);
 	}
 }
 

--- a/grobb/Basher_Nanrum.pl
+++ b/grobb/Basher_Nanrum.pl
@@ -30,13 +30,13 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(10307 => 2)) {
 	 	quest::say("Well dat be some of da eyeballses I askeded for. But I you needs ta give me three for da shiny.");
 		#:: Return two 10307 - Fire Beetle Eye
-		quest::summonitem(110307,2);
+		quest::summonitem(10307,2);
 	}
 	#:: Match one 10307 - Fire Beetle Eye
 	elsif (plugin::takeItems(10307 => 1)) {
 	 	quest::say("Well dat be some of da eyeballses I askeded for. But I you needs ta give me three for da shiny.");
 		#:: Return one 10307 - Fire Beetle Eye
-		quest::summonitem(110307,1);
+		quest::summonitem(10307,1);
 	}
 	#:: Return unused items
 	plugin::returnUnusedItems();

--- a/grobb/Bregna.pl
+++ b/grobb/Bregna.pl
@@ -13,7 +13,7 @@ sub EVENT_SAY {
 	elsif ($text=~/find da poshuns/i) {
 		quest::say("Take dis as it be all me know.");
 		#:: Give a 18651 - Note to the Troll
-		quest::summonitem(118651);
+		quest::summonitem(18651);
 		#:: Ding!
 		quest::ding();
 	}
@@ -24,7 +24,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13984 => 1)) {
 		quest::say("Now Kaglari won't be mad at Bregna.");
 		#:: Give a 12212 - Kaglari Mana Doll
-		quest::summonitem(112212);
+		quest::summonitem(12212);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -40,7 +40,7 @@ sub EVENT_ITEM {
 		if ($ExpansionSetting > 7) {
 			quest::say("Dis am gud. I see you've been talkin' to Garuuk. Methanks you fer da help. Take dis note back ta Garuuk so he knows you helped me. Tanks again!");
 			#:: Give a 28740 - Troll Receipt
-			quest::summonitem(128740);
+			quest::summonitem(28740);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -53,10 +53,10 @@ sub EVENT_ITEM {
 		elsif ($ExpansionSetting < 8) {
 			quest::say("I have no need for these items, $name.  You can have them back.");
 			#:: Return Items
-			quest::summonitem(126632);
-			quest::summonitem(126640);
-			quest::summonitem(126621);
-			quest::summonitem(126662);
+			quest::summonitem(26632);
+			quest::summonitem(26640);
+			quest::summonitem(26621);
+			quest::summonitem(26662);
 		}
 	}
 	#:: Return unused items

--- a/grobb/Carver_Cagrek.pl
+++ b/grobb/Carver_Cagrek.pl
@@ -18,7 +18,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItemsCoin(0,0,10,0, 13409 => 3)) {
 		quest::say("Bouts time you gets everting!! Here is you Grobb Oven Mittens. Dey good to keep you from hot stuff.");
 		#:: Give a 12211 - Grobb Oven Mittens
-		quest::summonitem(112211);
+		quest::summonitem(12211);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience
@@ -31,7 +31,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(12191 => 4)) {
 		quest::say("Gud werk!! Me already, err, founds, dung part of meal. Here we go. One Fungus Dung Pie!! Enjoys.");
 		#:: Give a 12210 - Fungus Dung Pie
-		quest::summonitem(112210);
+		quest::summonitem(12210);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/grobb/Hukulk.pl
+++ b/grobb/Hukulk.pl
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18792 => 1)) {
 		quest::say("Haaah!! Bow to Hukulk!! Hukulk make you feared.. make you powered! Dark power flow through you! Hate and Fear in your blood!");
 		#:: Give a 13530 - Black and Green Tunic*
-		quest::summonitem(113530);
+		quest::summonitem(13530);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/grobb/Kaglari.pl
+++ b/grobb/Kaglari.pl
@@ -27,7 +27,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13073 => 2, 13187 => 2)) {
 		quest::say("Good. Innoruuk get special gift. Not you, dis time. Here. Learning majik wid dis. You more want to [help Innoruuk]?");
 		#:: Give a 15093 - Spell: Burst of Flame
-		quest::summonitem(115093);
+		quest::summonitem(15093);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -41,7 +41,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13916 => 1)) {
 		quest::say("Good job. Dat help lerns um. Takes dis ta help ya lerns how ta do more hateful tings. Ya gots a good starts fer Him ta be prouds a ya.");
 		#:: Give a 15272 - Spell: Spirit Pouch
-		quest::summonitem(115272);
+		quest::summonitem(15272);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -55,7 +55,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(18791 => 1)) {
 		quest::say("Good.. Kaglari need you help.. Kaglari teach you majik now.  When you ready for task you tell Kaglari!!  Yooz reeturn to mez when yooz ar strongur, mez teech yooz bout da mor advanced tings.");
 		#:: Give a 13529 - Muck Stained Tunic*
-		quest::summonitem(113529);
+		quest::summonitem(13529);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/grobb/Ranjor.pl
+++ b/grobb/Ranjor.pl
@@ -24,7 +24,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18790 => 1)) {
 		quest::say("Arhh.. Ranjor mighty warrior.. Ranjor teach you warrior.. you fight for Ranjor now.");
 		#:: Give a 13528 - Mud Covered Tunic*
-		quest::summonitem(113528);
+		quest::summonitem(13528);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/grobb/Treskar.pl
+++ b/grobb/Treskar.pl
@@ -121,12 +121,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("Me talk to you 'bout dat when you do more to help Nightkeep!  Kill all Greenbloods!  Kill all froggies!");
 			#:: Return a 12190 - Huge Mushroom Head
-			quest::summonitem(112190);
+			quest::summonitem(12190);
 		}
 		else {
 			quest::say("<..Sniff, sniff, sniff..>  Me smell the blood of enemy in you.  You fool to talk to Nightkeep shadowknight!  Me bleed you if you no run!");
 			#:: Return a 12190 - Huge Mushroom Head
-			quest::summonitem(112190);
+			quest::summonitem(12190);
 		}
 	}
 	#:: Match three 13782 - Ruined Wolf Pelt and a 10307 - Fire Beetle Eye
@@ -145,16 +145,16 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("Me talk to you 'bout dat when you do more to help Nightkeep!  Kill all Greenbloods!  Kill all froggies!");
 			#:: Return a 13782 - Ruined Wolf Pelt 
-			quest::summonitem(113782);
+			quest::summonitem(13782);
 			#:: Return a 10307 - Fire Beetle Eye
-			quest::summonitem(110307);
+			quest::summonitem(10307);
 		}
 		else {
 			quest::say("<..Sniff, sniff, sniff..>  Me smell the blood of enemy in you.  You fool to talk to Nightkeep shadowknight!  Me bleed you if you no run!");
 			#:: Return a 13782 - Ruined Wolf Pelt 
-			quest::summonitem(113782);
+			quest::summonitem(13782);
 			#:: Return a 10307 - Fire Beetle Eye
-			quest::summonitem(110307);
+			quest::summonitem(10307);
 		}
 	}
 	#:: Match two 13088 - Snake Egg
@@ -177,16 +177,16 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("Me talk to you 'bout dat when you do more to help Nightkeep!  Kill all Greenbloods!  Kill all froggies!");
 			#:: Return a 13088 - Snake Egg
-			quest::summonitem(113088);
+			quest::summonitem(13088);
 			#:: Return a 13088 - Snake Egg
-			quest::summonitem(113088);
+			quest::summonitem(13088);
 		}
 		else {
 			quest::say("<..Sniff, sniff, sniff..>  Me smell the blood of enemy in you.  You fool to talk to Nightkeep shadowknight!  Me bleed you if you no run!");
 			#:: Return a 13088 - Snake Egg
-			quest::summonitem(113088);
+			quest::summonitem(13088);
 			#:: Return a 13088 - Snake Egg
-			quest::summonitem(113088);
+			quest::summonitem(13088);
 		}
 	}
 	#:: Match three 13916 - Deathfist Slashed Belt
@@ -209,20 +209,20 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("Me talk to you 'bout dat when you do more to help Nightkeep!  Kill all Greenbloods!  Kill all froggies!");
 			#:: Return a 13916 - Deathfist Slashed Belt
-			quest::summonitem(113916);
+			quest::summonitem(13916);
 			#:: Return a 13916 - Deathfist Slashed Belt
-			quest::summonitem(113916);
+			quest::summonitem(13916);
 			#:: Return a 13916 - Deathfist Slashed Belt
-			quest::summonitem(113916);
+			quest::summonitem(13916);
 		}
 		else {
 			quest::say("<..Sniff, sniff, sniff..>  Me smell the blood of enemy in you.  You fool to talk to Nightkeep shadowknight!  Me bleed you if you no run!");
 			#:: Return a 13916 - Deathfist Slashed Belt
-			quest::summonitem(113916);
+			quest::summonitem(13916);
 			#:: Return a 13916 - Deathfist Slashed Belt
-			quest::summonitem(113916);
+			quest::summonitem(13916);
 			#:: Return a 13916 - Deathfist Slashed Belt
-			quest::summonitem(113916);
+			quest::summonitem(13916);
 		}
 	}
 	#:: Match two 13403 - Wolf Meat and two 13070 - Snake Scales
@@ -245,24 +245,24 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("Me talk to you 'bout dat when you do more to help Nightkeep!  Kill all Greenbloods!  Kill all froggies!");
 			#:: Return a 13403 - Wolf Meat
-			quest::summonitem(113403);
+			quest::summonitem(13403);
 			#:: Return a 13403 - Wolf Meat
-			quest::summonitem(113403);
+			quest::summonitem(13403);
 			#:: Return a 13070 - Snake Scales
-			quest::summonitem(113070);
+			quest::summonitem(13070);
 			#:: Return a 13070 - Snake Scales
-			quest::summonitem(113070);
+			quest::summonitem(13070);
 		}
 		else {
 			quest::say("<..Sniff, sniff, sniff..>  Me smell the blood of enemy in you.  You fool to talk to Nightkeep shadowknight!  Me bleed you if you no run!");
 			#:: Return a 13403 - Wolf Meat
-			quest::summonitem(113403);
+			quest::summonitem(13403);
 			#:: Return a 13403 - Wolf Meat
-			quest::summonitem(113403);
+			quest::summonitem(13403);
 			#:: Return a 13070 - Snake Scales
-			quest::summonitem(113070);
+			quest::summonitem(13070);
 			#:: Return a 13070 - Snake Scales
-			quest::summonitem(113070);
+			quest::summonitem(13070);
 		}
 	}
 	#:: Match three 12199 - Black Shadow Tunic and two gold
@@ -290,18 +290,18 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("Me talk to you 'bout dat when you do more to help Nightkeep!  Kill all Greenbloods!  Kill all froggies!");
 			#:: Return a 12199 - Black Shadow Tunic
-			quest::summonitem(112199);
+			quest::summonitem(12199);
 			#:: Return a 12199 - Black Shadow Tunic
-			quest::summonitem(112199);
+			quest::summonitem(12199);
 			#:: Return Coins
 			quest::givecash($copper, $silver, $gold, $platinum);
 		}
 		else {
 			quest::say("<..Sniff, sniff, sniff..>  Me smell the blood of enemy in you.  You fool to talk to Nightkeep shadowknight!  Me bleed you if you no run!");
 			#:: Return a 12199 - Black Shadow Tunic
-			quest::summonitem(112199);
+			quest::summonitem(12199);
 			#:: Return a 12199 - Black Shadow Tunic
-			quest::summonitem(112199);
+			quest::summonitem(12199);
 			#:: Return Coins
 			quest::givecash($copper, $silver, $gold, $platinum);
 		}
@@ -310,7 +310,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(12199 => 1)) {
 		quest::say("Me change mind! Me want total of THREE ogre black shadow tunics. Ha Ha! And you also pay two gold for Nightkeep tax! Ha! Ha!");
 		#:: Return a 12199 - Black Shadow Tunic
-		quest::summonitem(112199);
+		quest::summonitem(12199);
 	}
 	#:: Return unused items
 	plugin::returnUnusedItems();

--- a/grobb/Urako.pl
+++ b/grobb/Urako.pl
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Tank you. You saved me neck. Kaglari not learn me mistake now. Me give you a [Kaglari mana doll].");
 			#:: Give a 12212 - Kaglari Mana Doll
-			quest::summonitem(112212);
+			quest::summonitem(12212);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -79,24 +79,24 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("Darkones no hates you, buts you not helps us enuff.");
 			#:: Return a 12213 - The Baker
-			quest::summonitem(112213);
+			quest::summonitem(12213);
 			#:: Return a 12214 - The Butcher
-			quest::summonitem(112214);
+			quest::summonitem(12214);
 			#:: Return a 12215 - The Captain
-			quest::summonitem(112215);
+			quest::summonitem(12215);
 			#:: Return a 12216 - The Minstrel
-			quest::summonitem(112216);
+			quest::summonitem(12216);
 		}
 		else {
 			quest::say("You die! Me Darkone!  We no frend to you.  You run now!");
 			#:: Return a 12213 - The Baker
-			quest::summonitem(112213);
+			quest::summonitem(12213);
 			#:: Return a 12214 - The Butcher
-			quest::summonitem(112214);
+			quest::summonitem(12214);
 			#:: Return a 12215 - The Captain
-			quest::summonitem(112215);
+			quest::summonitem(12215);
 			#:: Return a 12216 - The Minstrel
-			quest::summonitem(112216);
+			quest::summonitem(12216);
 		}
 	}
 	#:: Return unused items

--- a/grobb/a_prisoner.pl
+++ b/grobb/a_prisoner.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13311 => 1)) {
 		quest::say("Groak.. So you are a friend to the froglok. ..Grooakk.. I am soon to die. My precious legs are a delicacy here. Before I go I must contact my brother Grikk. He is a froglok forager in Innothule. Give him this vial. He will know what it means");
 		#:: Give a 13375 - Empty Vial
-		quest::summonitem(113375);
+		quest::summonitem(13375);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience based on level

--- a/halas/Cindl.pl
+++ b/halas/Cindl.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 	elsif ($text=~/mammoth hide parchment/i) {
 		quest::say("Jinkus must've sent ye fer some more mammoth hide parchment for his posters.  Here, take it, free o' charge, as a donation to the church and to the will o' the Tribunal as well.");
 		#:: Give a 12621 - Mammoth Hide Parchment
-		quest::summonitem(112621);
+		quest::summonitem(12621);
 	}
 	elsif ($text=~/shaman of justice/i) {
 		quest::say("The Shamans of Justice serve the will of the Tribunal. They search out those who defy the laws set by the Tribunal.");

--- a/halas/Dargon_McPherson.pl
+++ b/halas/Dargon_McPherson.pl
@@ -20,7 +20,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("Ach, 'tis good o' ye! Take this bottle of elixir to Everfrost Peaks. Find Talin O'Donal. He'll take the first sip, and then instruct ye on who else ye need to find. Do that, and I'll give ye a fine reward when ye return the empty elixir bottle. Good luck, then. Don't die.");
 			#:: Give a 13241 - Full Bottle of Elixir
-			quest::summonitem(113241);
+			quest::summonitem(13241);
 		}
 		#:: Match if faction is Indifferent
 		elsif ($faction == 5) {
@@ -58,12 +58,12 @@ sub EVENT_ITEM {
 		elsif ($faction == 5) {
 			quest::say("The Wolves o' the North show ye no ill will, but there's much ye must do t' earn our trust.  Perhaps ye should speak with Lysbith and inquire o' the gnoll bounty.");
 			#:: Return a 13245 - Empty Bottle of Elixir
-			quest::summonitem(113245);
+			quest::summonitem(13245);
 		}
 		else {
 			quest::say("Run while ye still can!! The Wolves o' the North will not tolerate yer presence!");
 			#:: Return a 13245 - Empty Bottle of Elixir
-			quest::summonitem(113245);
+			quest::summonitem(13245);
 		}
 	}
 	#:: Return unused items

--- a/halas/Dok.pl
+++ b/halas/Dok.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/collect the wax/i) {
 		quest::say("Grreatt!!  Take this wax jarr.  Head to any place ye can find the wee ones they call bixies. I'm afraid ye're going to hafta bash 'em and search to find out if they're carrying any honeycombs.  If they are, then ye can fill the jar with them and combine them, then return the full honeycomb jar to me. I'll be givin' ye a special candle if ye can do that fer me.");
 		#:: Give a 17958 - Empty Jar
-		quest::summonitem(117958);
+		quest::summonitem(17958);
 	}
 	elsif ($text=~/crime/i) { 
 		quest::say("Aye. I happened upon the crime scene, but too late, more's the pity.  I grabbed fer one of the rogues and got only a handful of his shirt.  Before I knew it, I was left holding his sweaty shirt and he was far from the scene.  I called fer the guards and they summoned the shaman.  Methinks one died and one got away in the chase.  I've heard rumors that the leader of [Clan McMannus] has spotted the culprit.  Ye should go to the leader of Clan McMannus and tell him ye're [searching for the fugitive].");
@@ -32,7 +32,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12222 => 1)) {
 		quest::say("Great work!! Now I can make more candles! Here ye are, me friend. I call this the Everburn Candle. It has a wee bit o' magic in it. I hope ye like it.");
 		#:: Give a 12220 - Everburn Candle
-		quest::summonitem(112220);
+		quest::summonitem(12220);
 		#:: Ding!
 		quest::ding();
 		#:: Set Factions
@@ -50,7 +50,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(12275 => 1, 12276 => 1, 12282 => 1, 13953 => 1)) {
 		quest::say("Here is your Candle o' Bravery.");
 		#:: Give a 12277 - Candle of Bravery
-		quest::summonitem(112277);
+		quest::summonitem(12277);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/halas/Dun_McDowell.pl
+++ b/halas/Dun_McDowell.pl
@@ -14,12 +14,12 @@ sub EVENT_SAY {
 	if ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -28,7 +28,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18762 => 1)) {
 		quest::say("Ah.. ye wish to be a member o' the White Rose, then. eh? Well, let's train ye fer a bit. and see if ye've got what it takes. Once you are ready to begin adventuring make sure you see Lysbith first, she might have a few tasks for you.  Return to me for guidance anytime, I have much to teach you, from the secrets of the profession, to the various [trades] you may wish to dabble in.");
 		#:: Give a 13513 - Torn White Tunic*
-		quest::summonitem(113513);
+		quest::summonitem(13513);
 		#:: Ding!
 		quest::ding();
 		#:: Set faction

--- a/halas/Greta_Terrilon.pl
+++ b/halas/Greta_Terrilon.pl
@@ -2,7 +2,7 @@ sub EVENT_SAY {
 	if ($text=~/some ink/i) {
 		quest::say("Jinkus must've sent ye fer some of me special ink made from the pigement of th' dalura flower.  Ye may take some free o' charge as a donation to the church and to the will of the Tribunal as well.");
 		#:: Give a 12619 - Vial of Datura Ink
-		quest::summonitem(112619);
+		quest::summonitem(12619);
 	}
 	elsif ($text=~/shaman of justice/i) {
 		quest::say("The Shamans of Justice serve the will of the Tribunal. They search out those who defy the laws set by the Tribunal.");

--- a/halas/Hetie_McDonald.pl
+++ b/halas/Hetie_McDonald.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/muffins/i) {
 		quest::say("Take dis crate and fill it with hand crafted muffins.  They are much better than store bought."); 
 		#:: Give a 17881 - Muffin Crate
-		quest::summonitem(117881);
+		quest::summonitem(17881);
 	}
 	elsif ($text=~/shipment of bread/i) {
 		quest::say("Far away in the Southern Plains of Karana a centaur named Meadowgreen makes the best bread. If you were to get some for us, it sure would help.");

--- a/halas/Holana_Oleary.pl
+++ b/halas/Holana_Oleary.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("So, ye're the next to be tested, then, eh?! I pray ye're able to return. Ye'll need to take this note to Einhorst in Clan McMannus' fishing village in the Plains o' Karana. He'll hand ye the monthly Karana clover shipment to be returned to me. Just remember, dinnae stop running! Do ye [need directions to Clan McMannus]?");
 			#:: Give a 18831 - Tattered Note
-			quest::summonitem(118831);
+			quest::summonitem(18831);
 		}
 		else {
 			quest::say("Run while ye still can!! The Wolves o' the North will not tolerate yer presence!");
@@ -54,7 +54,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Run while ye still can!! The Wolves o' the North will not tolerate yer presence!");
 			#:: Return a 13962 - Karana Clover Shipment
-			quest::summonitem(113962);
+			quest::summonitem(13962);
 		}
 	}
 	#:: Return unused items

--- a/halas/Jinkus_Felligan.pl
+++ b/halas/Jinkus_Felligan.pl
@@ -61,7 +61,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12621 => 1, 12619 => 1)) {
 		quest::say("Here is th' bounty poster. Take it to a bank guard in Qeynos, immediately!");
 		#:: Give a 12620 - Wanted Poster
-		quest::summonitem(112620);
+		quest::summonitem(12620);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/halas/Kylan_O-Danos.pl
+++ b/halas/Kylan_O-Danos.pl
@@ -14,12 +14,12 @@ sub EVENT_SAY {
 	if ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -28,7 +28,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18760 => 1)) {
 		quest::say("Greetin's! We are the mighty Wolves o' the North, protectors o' Halas, and we must work hard t' keep it safe fer our citizens. Here is our tunic, it identifies ye as a proud warrior o' this great city. Once you are ready to begin your training please make sure that you see Lysbith, she can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13511 - Patched Fur Tunic*
-		quest::summonitem(113511);
+		quest::summonitem(13511);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/halas/Lysbith_McNaff.pl
+++ b/halas/Lysbith_McNaff.pl
@@ -20,7 +20,7 @@ sub EVENT_SAY {
 	elsif ($text=~/protect the pass/i) {
 		quest::say("Then travel to the Everfrost Peaks and take this pack with ye. I want ye to return this pack to me when it is filled with the beaded ice necklaces o' the ice goblins. When it is filled, combine the items and return it to me and I'll decide whether ye deserve a reward fer yer deed.");
 		#:: Give a 17944 - Empty Bag (*Bag for Ice Necklaces) 
-		quest::summonitem(117944);
+		quest::summonitem(17944);
 	}
 }	
 	

--- a/halas/Margyn_McCann.pl
+++ b/halas/Margyn_McCann.pl
@@ -27,7 +27,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13729 => 1)) {
 		quest::say("We can now rest assured that justice has been served. Ye'll be a valuable asset to our court. Take and remember this spell, Spirit o' the Bear. I hope ye've attained the necessary skills to scribe it. If not, I'm sure ye soon will. Go now, and serve justice.");
 		#:: Give a 15279 - Spell: Spirit of Bear
-		quest::summonitem(115279);
+		quest::summonitem(15279);
 		#:: Ding!
 		quest::ding();
 		#:: Set Factions
@@ -47,7 +47,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(18761 => 1)) {
 		quest::say("Welcome t' the Church o' the Tribunal. Here, we practice the will o' the Six Hammers. This is our guild tunic - wear it with pride and represent us well.");
 		#:: Give a 13512 - Faded Blue Tunic*
-		quest::summonitem(113512);
+		quest::summonitem(13512);
 		#:: Ding!
 		quest::ding();
 		#:: Set Factions

--- a/halas/Marton_Stringsinger.pl
+++ b/halas/Marton_Stringsinger.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 	elsif ($text=~/deliver mail to Qeynos/i) {
 		quest::say("Take this letter to Tralyn Marsinger in Qeynos. You can find him at the bard guild hall. I am sure he will compensate you for your troubles..");
 		#:: Give a 18153 - Bardic Letter (Qeynos)
-		quest::summonitem(118153);
+		quest::summonitem(18153);
 	}
 }
 

--- a/halas/Renth_McLanis.pl
+++ b/halas/Renth_McLanis.pl
@@ -92,7 +92,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Run while ye still can!! The Wolves o' the North will not tolerate yer presence!");
 			#:: Return a 13246 - Box of Remains
-			quest::summonitem(113246);
+			quest::summonitem(13246);
 		}
 	}
 	#:: Match a 12227 - Barbarian head Identifies as Basil's Head
@@ -119,7 +119,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Run while ye still can!! The Wolves o' the North will not tolerate yer presence!");
 			#:: Return a 12227 - Barbarian head
-			quest::summonitem(112227);
+			quest::summonitem(12227);
 		}
 	}
 	#:: Match a 12225 - Barbarian head (Identifies as Paglan's Head)
@@ -146,7 +146,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Run while ye still can!! The Wolves o' the North will not tolerate yer presence!");
 			#:: Return a 12227 - Barbarian head
-			quest::summonitem(112225);
+			quest::summonitem(12225);
 		}
 	}
 	#:: Return unused items

--- a/halas/Teria_O-Danos.pl
+++ b/halas/Teria_O-Danos.pl
@@ -18,7 +18,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13961 => 1)) {
 		quest::say("Ye've returned!! How wonderful! The people o' Halas thank ye! It isn't often we get to indulge ourselves in the delicacies o' warmer climates. Here ye go, me friend. Ye've completed the delivery in good time. I hope ye deliver more often. Here, try some of me new creation.. Lion Delight.");
 		#:: Give a 12221 - Lion Delight
-		quest::summonitem(112221);
+		quest::summonitem(12221);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/halas/Thadres_Thyme.pl
+++ b/halas/Thadres_Thyme.pl
@@ -21,7 +21,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18136 => 1, 18137 => 1, 18138 => 1)) {
 		quest::say("Thank you, thank you. Let me read them. Oh! How could I want these brewing recipes after they made my brother insane? Where are they? I think this is all of them. Take them away from me! Delius can smile upon me now.");
 		#:: Give a 18139 - Garsen's Brewing List
-		quest::summonitem(118139);
+		quest::summonitem(18139);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/halas/Waltor_Felligan.pl
+++ b/halas/Waltor_Felligan.pl
@@ -34,7 +34,7 @@ sub EVENT_SAY {
 		if ($faction <= 4) {
 			quest::say("As the wooly spiderlings get ready to molt, they'll carry wooly fungus. Oftentimes, one can find wooly fungus growing on their bellies. I use this in me healing practices. I'll reward ye if ye can fill this jar full o' the valuable fungus. Don't forget to combine them before ye return it to me. And have yerself some rations handy, or ye may find yerself snacking on this tasteless food source.");
 			#::  Give a 17946 - Empty Jar (identifies as "Jar for Wooly Fungus")
-			quest::summonitem(117946);
+			quest::summonitem(17946);
 		}
 		else {
 			quest::say("The scales o' the Shamans o' Justice dinnae tip in yer favor. Ye'd best flee ye still have the chance.");
@@ -72,8 +72,8 @@ sub EVENT_ITEM {
 		else {
 			quest::say("The scales o' the Shamans o' Justice dinnae tip in yer favor. Ye'd best flee ye still have the chance.");
 			#:: Return two 13967 - Wooly Fungus
-			quest::summonitem(113967);
-			quest::summonitem(113967);
+			quest::summonitem(13967);
+			quest::summonitem(13967);
 		}
 	}
 	#:: Match a 13445 - Mammoth Steaks
@@ -89,7 +89,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("The scales o' the Shamans o' Justice dinnae tip in yer favor. Ye'd best flee ye still have the chance.");
 			#:: Return one 13445 - Mammoth Steaks
-			quest::summonitem(113445);
+			quest::summonitem(13445);
 		}
 	}
 	#:: Match a 13966 - Jar of Fungus
@@ -117,7 +117,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("The scales o' the Shamans o' Justice dinnae tip in yer favor. Ye'd best flee ye still have the chance.");
 			#:: Return one 13966 - Jar of Fungus
-			quest::summonitem(113966);
+			quest::summonitem(13966);
 		}
 	}
 	#:: Return unused items

--- a/highpasshold/Bryan_McGee.pl
+++ b/highpasshold/Bryan_McGee.pl
@@ -24,7 +24,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12366 => 1)) {
 		quest::say("On second thought.. You can do a little favor for me first. An associate of mine has asked me to acquire a case of spirits for him. Take this box and seek out what is needed to fill it. Inside you will combine the spirits of Lendel's Grand Lager, Gator Gulp Ale, Blackburrow Swig, Tunare's Finest, Underfoot Triple Bock, Frozen Toe Rum, Blood Spirit, Vasty Deep Ale, Clockwork Oil Stout and the legendary..[Oblong Bottle].");
 		#:: Give a 17984 - Bottle Crate
-		quest::summonitem(117984);
+		quest::summonitem(17984);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -42,7 +42,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(12365 => 1)) {
 		quest::say("I cannot believe you actually acquired all those drinks!! You do good work, kid. Here is the gem as I promised. And a few plat for good measure. Don't let it be said that the Axe doesn't treat his friends right.");
 		#:: Give a 12348 - Gem of Stamina
-		quest::summonitem(112348);
+		quest::summonitem(12348);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/highpasshold/Cytodl_Krish.pl
+++ b/highpasshold/Cytodl_Krish.pl
@@ -5,7 +5,7 @@ sub EVENT_SAY {
 	elsif ($text=~/messages for neriak/i) {
 		quest::say("Yes! Yes, of course. I have been waiting for you. The last four couriers made the mistake of asking the High Keep Guards for directions. Now they are breathing dirt, six feet under. Take this to Neriak at once.");
 		#:: Give a 18889 - Sealed Letter
-		quest::summonitem(118889 => 1);
+		quest::summonitem(18889 => 1);
 	}
 }
 

--- a/highpasshold/Jovan.pl
+++ b/highpasshold/Jovan.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12114 => 1)) {
 		quest::say("<SLURP!!>  Ahh thhhhat'thh betterr. Take thithhh. <BURP!>");
 		#:: Give a 19006 - Icon of the Fervent
-		quest::summonitem(119006);
+		quest::summonitem(19006);
 		#:: Ding!
 		quest::ding();
 		#:: Depop with spawn timer active

--- a/highpasshold/Marlin_Shirtov.pl
+++ b/highpasshold/Marlin_Shirtov.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13352 => 1)) {
 		quest::say("Ahh!! The silk evening tunic. Mistress Anna will look stunning in this. Here is the key to Princess Lenya's cell. Good luck, hero!");
 		#:: Give item 20008 - Brass Key
-		quest::summonitem(120008);
+		quest::summonitem(20008);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/highpasshold/Prak.pl
+++ b/highpasshold/Prak.pl
@@ -47,7 +47,7 @@ sub EVENT_ITEM {
 		else {
 			#:: Confirmed no text on live.
 			#:: Return a 18795 - Letter for Prak
-			quest::summonitem(118795);
+			quest::summonitem(18795);
 		}
 	}
 	#:: Match a 13793 - Stald's Badge
@@ -56,7 +56,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Ah, boy! Looks like I owe Kaden two plat... I thought you'd fumble it up for sure. Well, you've impressed me friend. Here, take this back to Zan... I'll make sure to note your fine work to Carson, too, next time we speak.");
 			#:: Give a 18028 - Message to Zannsin
-			quest::summonitem(118028);
+			quest::summonitem(18028);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -71,7 +71,7 @@ sub EVENT_ITEM {
 		else {
 			#:: Confirmed no text on live.
 			#:: Return a 13793 - Stald's Badge
-			quest::summonitem(113793);
+			quest::summonitem(13793);
 		}	
 	}
 	#:: Return unused items

--- a/kerraridge/Errrak_Thickshank.pl
+++ b/kerraridge/Errrak_Thickshank.pl
@@ -19,7 +19,7 @@ sub EVENT_ITEM {
 		#:: Ding!
 		quest::ding();
 		#:: Give a 10139 - Bone Talisman
-		quest::summonitem(110139);
+		quest::summonitem(10139);
 		#:: Set faction
 		quest::faction(382,30);	# + Kerra Isle
 	}

--- a/kerraridge/Feskr_Drinkmaker.pl
+++ b/kerraridge/Feskr_Drinkmaker.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 12360 => 1, 14914 => 1, 14915 => 1, 17969 => 1)) {
 		quest::say("Ahhh. This will help. Many Kerrans will like these. Here. Take this old bag. I have too many. Maybe it help you.");
 		#:: Give a 17032 - Rough Leather Sack
-		quest::summonitem(117032);
+		quest::summonitem(17032);
 		#:: Ding!
 		quest::ding();
 		#:: Set faction

--- a/kerraridge/a_banished_kerran.pl
+++ b/kerraridge/a_banished_kerran.pl
@@ -15,13 +15,13 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12369 => 1)) {
 		quest::say("Ashen Order!!  Prrr.. My order.  I have been expecting one of us.  Prrr.. Help me rejoin my native land.  Take this box.  Combine all the [remains of Thipt] within the box and return it to me.  This shall aid me in my redemption.");
 		#:: Give a 17985 - Box With Pawprints
-		quest::summonitem(117985);
+		quest::summonitem(17985);
 	}
 	#:: Match a 12371 - Box of Cat Bones
 	elsif (plugin::takeItems(12371 => 1)) {
 		quest::say("Prrr.. Thank you brother of Ashen. I can now spend my time upon this island in peace, until my penance is serrrved. He dabs his paw into the mud and places it upon a tattered parchment. Take this message to Puab. Farrrwell.");
 		#:: Give a 28055 - Tattered Parchment
-		quest::summonitem(128055);
+		quest::summonitem(28055);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/kerraridge/kerran_tseq.pl
+++ b/kerraridge/kerran_tseq.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 6344 => 1)) {
 		quest::say("Rreeee! Great toy. Shiny. We not need this old toy anymore. You take. Now go way, this our toy, we play.");
 		#:: Give a 13748 - Kerran Toy
-		quest::summonitem(113748);
+		quest::summonitem(13748);
 		quest::faction( 382, 20);	# + Kerra Isle
 	}
 	#:: Return unused items

--- a/oasis/Taldrik_Stumpystout.pl
+++ b/oasis/Taldrik_Stumpystout.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 	elsif ($text=~/cask/i) {
 		quest::say("Why a holy cask is what ye will need of course! Find the ingredients that I asked you for before and combine them within this holy cask along with barley from the forests of Kithicor and water summoned from none other than yourself. After doing this if the gods have smiled upon you a thick and hearty keg of Brells Blessed Stout will be created. Give this to me along with a Rat sandwich to enjoy while I sip the finest of ales as well as your Initiate symbol that you carry now and I will be sure to reward you.");
 		#:: Give a 17070 - Holy Cask
-		quest::summonitem(117070);
+		quest::summonitem(17070);
 	}
 }
 

--- a/oggok/Ambassador_K-Ryn.pl
+++ b/oggok/Ambassador_K-Ryn.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18842 => 1)) {
 		quest::say("Another young warrior. I pray you shall not meet the fate of the last twelve. Here then. Take this report to Mistress Seloxia at once. And stay clear of the Froglok lair called Gukk.");
 		#:: Give a 18843 - Sealed Letter
-		quest::summonitem(118843);
+		quest::summonitem(18843);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/oot/Sentry_Xyrin.pl
+++ b/oot/Sentry_Xyrin.pl
@@ -64,7 +64,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12134 => 1)) {
 		quest::say("Ahhhh! I am energized! Come! Let us show these undead the greatness of Erollisi Marr!");
 		#:: give a 12135 - Empty Potion of Marr
-		quest::summonitem(112135);
+		quest::summonitem(12135);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/poknowledge/#Roosevelt.pl
+++ b/poknowledge/#Roosevelt.pl
@@ -2,7 +2,7 @@
 sub EVENT_SAY {
 	if($text=~/interested/i) { 
 		quest::say("Great! Take this tool. It'll help you track down your targets. Be warned, however! Your tool is not protected from sabatoge, and does not work well if your target roams about, instead of staying in a single spot. My boys know this, and will take advantage! If you have trouble finding a particular target, Icarus may be able to help. Let me know when you are [" . quest::saylink("ready") . "].");
-		quest::summonitem(111901); # Item: Wand of Metacrystalline Teleportation
+		quest::summonitem(11901); # Item: Wand of Metacrystalline Teleportation
 	}
 	if(!quest::istaskactive(222)){
 		if($text=~/Hail/i) {
@@ -158,7 +158,7 @@ sub EVENT_SAY {
 					)
 				);
 				$client->Message(3, "You have been awarded a special item!"); 
-				quest::summonitem(124688); # Item: Peace Be With You
+				quest::summonitem(24688); # Item: Peace Be With You
 				quest::enabletitle(6);
 				plugin::Whisper("You have been awarded a new title!");
 				quest::setglobal("halloween_ratter_complete",14,5,"D30");

--- a/poknowledge/Dieffer_Wolfhugger.pl
+++ b/poknowledge/Dieffer_Wolfhugger.pl
@@ -124,7 +124,7 @@ sub EVENT_ITEM {
 			
 			if($loop_count > 100){
 				$client->Message(0, "I tried to give you an item you already have. Hand this back to me for another roll at the grand prize.");
-				quest::summonitem(124688); # (124688) Peace Be With You 
+				quest::summonitem(24688); # (124688) Peace Be With You 
 				$found_prize = 1;
 			}
 			

--- a/qey2hh1/Brother_Estle.pl
+++ b/qey2hh1/Brother_Estle.pl
@@ -42,7 +42,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13910 => 1)) {
 		quest::say("Thank you. Now I may cleanse the bodies of the new converts and help them enter into a new life. I also have this. It was given to me by a dying gnoll of all things. They belong to Brother Hayle. The gnoll's last words were 'Free him.' Make sure High Priestess Jahnda gets this. Be swift!");
 		#:: Give a 13911 - PrayerBeads
-		quest::summonitem(113911);
+		quest::summonitem(13911);
 		#:: Ding
 		quest::ding();
 		#:: Set factions

--- a/qey2hh1/Chrislin_Baker.pl
+++ b/qey2hh1/Chrislin_Baker.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13063 => 1, 13051 => 1)) {
 		quest::emote("gives you a hug. 'Thank you so much. I did some cleaning after you left and found this behind a barrel. It may have been left behind by the person who took my materials. You can have it.'");
 		#:: Give a 12100 - Bandit Sash
-		quest::summonitem(112100);
+		quest::summonitem(12100);
 		#:: Ding!
 		quest::ding();
 		#:: Part of Enchanter Epic 1.0

--- a/qey2hh1/Einhorst_McMannus.pl
+++ b/qey2hh1/Einhorst_McMannus.pl
@@ -31,7 +31,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18831 => 1)) {
 		quest::say("Yes. We almost forgot of the shipment of Karana clovers. Here you are, my friend. Back to the north with you. I am sure the Shamans of Justice will need this.");
 		#:: Give a 13962 - Karana Clover Shipment
-		quest::summonitem(113962);
+		quest::summonitem(13962);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/qey2hh1/Frostbite.pl
+++ b/qey2hh1/Frostbite.pl
@@ -8,7 +8,7 @@ sub EVENT_ITEM {
 	#:: Match a 12140 - Regurgitonic
 	if (plugin::takeItems(12140 => 1)) {
 		#:: Give a 13383 - Koalindl Fish
-		quest::summonitem(113383);
+		quest::summonitem(13383);
 		#:: Ding!
 		quest::ding();
 	}

--- a/qey2hh1/Gindlin_Toxfodder.pl
+++ b/qey2hh1/Gindlin_Toxfodder.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItemsCoin(0, 0, 20, 0, 14018 => 2, 13795 => 1)) {
 		quest::say("Here.  I could care less what you do with this.  Hopefully you'll lay some on the Circle of Unseen Hands.");
 		#:: Give a 14015 - Spider Venom
-		quest::summonitem(114015);
+		quest::summonitem(14015);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/qey2hh1/Innkeep_Rislarn.pl
+++ b/qey2hh1/Innkeep_Rislarn.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 	elsif ($text=~/muffin supply/i) {
 		quest::say("Thanks, you're a pal. Take this crate and fill it with muffins, then seal it up and bring the Full Muffin Crate back to me. Don't go trying to pass off that store bought stuff on me either, I need fresh baked muffins. The ones in the stores are already too old and will get moldy too fast, so I don't want those.");
 		#:: Give a 17881 - Muffin Crate
-		quest::summonitem(117881);
+		quest::summonitem(17881);
 	}
 }
 

--- a/qey2hh1/Lempeck_Hargrin.pl
+++ b/qey2hh1/Lempeck_Hargrin.pl
@@ -29,7 +29,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13954 => 1)) {
 		quest::say("Thank you!! I felt the madness nearing my brain, but now I feel much better. Please take this as thanks - it is all I have to donate to Astaed Wemor. Be sure he gets it. I shall thank Rodcet Nife every day for sending help.");
 		#:: Give a 13970 - Rusty Scythe
-		quest::summonitem(113970);
+		quest::summonitem(13970);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/qey2hh1/Minda.pl
+++ b/qey2hh1/Minda.pl
@@ -18,7 +18,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(12103 => 1)) {
 		quest::say("May the Rainkeeper keep you safe. I thank you. Here is the empty chalice. By the way, inform your superior that the operations of the [Karana bandits] are getting closer to Qeynos.");
 		#:: Give a 12104 - Empty Chalice
-		quest::summonitem(112104);
+		quest::summonitem(12104);
 		#:: Ding
 		quest::ding();
 		#:: Set factions

--- a/qey2hh1/Misla_McMannus.pl
+++ b/qey2hh1/Misla_McMannus.pl
@@ -5,7 +5,7 @@ sub EVENT_SAY {
 	elsif ($text=~/deliver lion meat to halas/i) {
 		quest::say("Very well then, here you go. Be sure to deliver this to Teria O' Danos. She will be on of the first people you meet in Halas.");
 		#:: Give a 13961 - Lion Meat Shipment
-		quest::summonitem(113961);
+		quest::summonitem(13961);
 	}
 }
 

--- a/qey2hh1/Mistrana_Two_Notes.pl
+++ b/qey2hh1/Mistrana_Two_Notes.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/qeynos/i) {
 		quest::say("Take this letter to Tralyn Marsinger in Qeynos.  You can find him at the bard guild hall.  I am sure he will compensate you for your troubles.");
 		#:: Give a 18150 - Bardic Letter (Qeynos)
-		quest::summonitem(118150);
+		quest::summonitem(18150);
 	}
 }
 

--- a/qey2hh1/Yiz_Pon.pl
+++ b/qey2hh1/Yiz_Pon.pl
@@ -5,7 +5,7 @@ sub EVENT_SAY {
 	elsif ($text=~/beasts|message/i) {
 		quest::say("Here... No time left... Take this please... My brother [Hyrill] is staying in [Freeport]. Please... Ugh... Must keep moving...");
 		#:: Give a 18010 - Torn Parchment
-		quest::summonitem(118010);
+		quest::summonitem(18010);
 		#:: Spawn one and only one The Western Plains of Karana >> a_Splitpaw_assassin (12182)
 		quest::unique_spawn(12182, 0, 0, -15188.57, 1270.43, 68.72, 109.0);
 	}
@@ -27,7 +27,7 @@ sub EVENT_SAY {
 	elsif ($text=~/message/i) {
 		quest::say("Hurry now and take this to my brother, Hyrill Pon in Freeport, and before you go take that skull back from the assassin.");
 		#:: Give a 18010 - Torn Parchment
-		quest::summonitem(118010);
+		quest::summonitem(18010);
 		#:: Spawn one and only one The Western Plains of Karana >> a_Splitpaw_assassin (12182)
 		quest::unique_spawn(12182, 0, 0, -15188.57, 1270.43, 68.72, 109.0);
 	}

--- a/qeytoqrg/Axe_Broadsmith.pl
+++ b/qeytoqrg/Axe_Broadsmith.pl
@@ -26,7 +26,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13397 => 1)) {
 		quest::say("So you have returned. Victory is yours, young Steel Warrior. Take this letter of recommendation to Brin Stolunger at the arena in Qeynos. You have passed.");
 		#:: Give a 18895 - Letter of Recommendation
-		quest::summonitem(118895);
+		quest::summonitem(18895);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/qeytoqrg/Baobob_Miller.pl
+++ b/qeytoqrg/Baobob_Miller.pl
@@ -86,7 +86,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Hmm.. I really would not feel comfortable helping you in that way. You need to prove yourself to me by aiding my friends and family in the Plains of Karana before I will help you.");
 			#:: Return a 13755 - High Quality Wolf Skin and 21 gold pieces
-			quest::summonitem(113755);
+			quest::summonitem(13755);
 			quest::givecash($copper, $silver, $gold, $platinum);
 		}
 	}
@@ -110,7 +110,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Hmm.. I really would not feel comfortable helping you in that way. You need to prove yourself to me by aiding my friends and family in the Plains of Karana before I will help you.");
 			#:: Return a 13754 - Medium Quality Wolf Skin and 15 gold pieces
-			quest::summonitem(113754);
+			quest::summonitem(13754);
 			quest::givecash($copper, $silver, $gold, $platinum);
 		}
 	}
@@ -134,7 +134,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Hmm.. I really would not feel comfortable helping you in that way. You need to prove yourself to me by aiding my friends and family in the Plains of Karana before I will help you.");
 			#:: Return a 13753 - Low Quality Wolf Skin and 5 gold pieces
-			quest::summonitem(113753);
+			quest::summonitem(13753);
 			quest::givecash($copper, $silver, $gold, $platinum);
 		}
 	}

--- a/qeytoqrg/Chanda_Miller.pl
+++ b/qeytoqrg/Chanda_Miller.pl
@@ -88,7 +88,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Hmm.. I really would not feel comfortable helping you in that way. You need to prove yourself to me by aiding my friends and family in the Plains of Karana before I will help you.");
 			#:: Return a 13752 - High Quality Bear Skin and 21 gold pieces
-			quest::summonitem(113752);
+			quest::summonitem(13752);
 			quest::givecash($copper, $silver, $gold, $platinum);
 		}
 	}
@@ -112,7 +112,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Hmm.. I really would not feel comfortable helping you in that way. You need to prove yourself to me by aiding my friends and family in the Plains of Karana before I will help you.");
 			#:: Return a 13751 - Medium Quality Bear Skin and 15 gold pieces
-			quest::summonitem(113751);
+			quest::summonitem(13751);
 			quest::givecash($copper, $silver, $gold, $platinum);
 		}
 	}
@@ -136,7 +136,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Hmm.. I really would not feel comfortable helping you in that way. You need to prove yourself to me by aiding my friends and family in the Plains of Karana before I will help you.");
 			#:: Return a 13750 - Low Quality Bear Skin and 5 gold pieces
-			quest::summonitem(113750);
+			quest::summonitem(13750);
 			quest::givecash($copper, $silver, $gold, $platinum);
 		}
 	}

--- a/qeytoqrg/Gnasher_Furgutt.pl
+++ b/qeytoqrg/Gnasher_Furgutt.pl
@@ -9,7 +9,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18800 => 1)) {
 		quest::say("Ah. Good for you! Here you are. Take this to McNeal, but next time there will be no stout if there are no weapons.");
 		#:: Give a 13131 - Case of Blackburrow Stout
-		quest::summonitem(113131);
+		quest::summonitem(13131);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/qeytoqrg/Guard_Cheslin.pl
+++ b/qeytoqrg/Guard_Cheslin.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/donate/i) {
 		quest::say("Of course I shall donate to that esteemed order. Here you are, my good friend. Now run along before you are injured by some nasty creature. By the way, you should speak with my fellow guard, Leopold. He also would donate.");
 		#:: Give a 13295 - Donation
-		quest::summonitem(113295);
+		quest::summonitem(13295);
 	}
 	elsif ($text=~/^illusion$/i) {
 		quest::say("Yes!! I seem to have dropped some of my [Illusion cards].");
@@ -68,7 +68,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 		quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
 		#:: Give a 18839 - Sealed Letter
-		quest::summonitem(118839);
+		quest::summonitem(18839);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -92,7 +92,7 @@ sub EVENT_ITEM {
 		if (plugin::check_mq_handin(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 			quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
 			#:: Give a 18839 - Sealed Letter
-			quest::summonitem(118839);
+			quest::summonitem(18839);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -120,7 +120,7 @@ sub EVENT_ITEM {
 		if (plugin::check_mq_handin(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 			quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
 			#:: Give a 18839 - Sealed Letter
-			quest::summonitem(118839);
+			quest::summonitem(18839);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -148,7 +148,7 @@ sub EVENT_ITEM {
 		if (plugin::check_mq_handin(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 			quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
 			#:: Give a 18839 - Sealed Letter
-			quest::summonitem(118839);
+			quest::summonitem(18839);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -176,7 +176,7 @@ sub EVENT_ITEM {
 		if (plugin::check_mq_handin(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 			quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
 			#:: Give a 18839 - Sealed Letter
-			quest::summonitem(118839);
+			quest::summonitem(18839);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions

--- a/qeytoqrg/Guard_Leopold.pl
+++ b/qeytoqrg/Guard_Leopold.pl
@@ -5,7 +5,7 @@ sub EVENT_SAY {
 	elsif ($text=~/donate/i) {
 		quest::say("Why, yes! I would love to donate to the Temple of Thunder. My father was a brave and noble member of that order. Here you are. You should ask Guard Cheslin also. His father and mine are both members of Thunder. Now, move along!");
 		#:: Give a 13294 - Donation
-		quest::summonitem(113294);
+		quest::summonitem(13294);
 	}
 }
 

--- a/qeytoqrg/Konem_Matse.pl
+++ b/qeytoqrg/Konem_Matse.pl
@@ -22,7 +22,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18921 => 1)) {
 		quest::say("Oh I see.. Phin's always after me about something. I mean, it's not my fault the order hasn't come in yet. Hey, since I'm so busy right now, why don't you be a friend and take this back to Phin for me, huh?");
 		#:: Give a 18922 - Grathin's Invoice
-		quest::summonitem(118922);
+		quest::summonitem(18922);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/qeytoqrg/Neclo_Rheslar.pl
+++ b/qeytoqrg/Neclo_Rheslar.pl
@@ -11,7 +11,7 @@ sub EVENT_ITEM {
 		if ($faction <= 5) {
 			quest::say("Ah.. Hello friend.. So, I see Daenor sent you.. Uh huh, ok.. Here's something that will be very useful for you. Practice this well, friend.. It will help protect you in this harsh world.");
 			#:: Give a 15109 - Spell: Elemental Armor
-			quest::summonitem(115109);
+			quest::summonitem(15109);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -25,7 +25,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("The Order of Three has been monitoring your recent activities, and we are appalled by you and your actions! Now, begone!");
 			#:: Return a a 18823 - Note to Neclo
-			quest::summonitem(118823);
+			quest::summonitem(18823);
 		}
 	}
 	#:: Return unused items

--- a/qeytoqrg/Niclaus_Ressinn.pl
+++ b/qeytoqrg/Niclaus_Ressinn.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 	elsif ($text=~/parchment/i) {
 		quest::say("I believe it is from a spell book of some kind and I do not have a working knowledge of things arcane. Perhaps you could help? Take it. I am sure someone in Qeynos could decipher it. I must remain here to gather more evidence but please return to me with anything you discover.");
 		#:: Give a 13718 - Torn Parchment
-		quest::summonitem(113718);
+		quest::summonitem(13718);
 	}
 }
 
@@ -62,7 +62,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13722 => 1)) {
 		quest::say("Excellent! Rodcet smiles upon us this day! Here, please take this pouch of evidence to Jahnda in the Temple of Life. She will know what we must do. I will remain here to keep an eye out for the minions of Bertoxxlous. Also, accept this small reward as a token of my appreciation of your efforts to rid Norrath of the influence of the Plaguebringer.");
 		#:: Give a 13724 - Pouch of Evidence
-		quest::summonitem(113724);
+		quest::summonitem(13724);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/qeytoqrg/Rephas.pl
+++ b/qeytoqrg/Rephas.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13072 => 1)) {
 		quest::say("Ahh yes..  These are a little small, but still some good eating, if you know how to cook 'em of course..   Here ya go, enjoy and may Karana keep your fields lush and green.");
 		#:: Give a 13719 - Grilled Rat Ears
-		quest::summonitem(113719);
+		quest::summonitem(13719);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -30,7 +30,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13719 => 1)) {
 		quest::say("Wha?..   Ah, I guess it's a bit of an acquired taste..  Oh well, your loss..  Here, take this..  They ain't no ears, but it's the least I could do..   And if ya find any more rat ears, good ol' Rephas here will be glad to take 'em off your hands for ya!");
 		#:: Give a 13076 - Fish Scales
-		quest::summonitem(113076);
+		quest::summonitem(13076);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -45,7 +45,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13050 => 3)) {
 		quest::say("Wow!..  How big was the dang varmint that these come off of?!  Bigger'n a ol' grizzly, I bet!  You've earned this, my friend!  It's my own secret recipe for rat ear pie..  sure is tasty, easy to make, and keeps your belly full while you're running about in the hills and such.  Take care, and may Karana keep your path clear and our lakes full.");
 		#:: Give a 18103 - Rat Ear Pie
-		quest::summonitem(118103);
+		quest::summonitem(18103);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/rivervale/Beek_Guinders.pl
+++ b/rivervale/Beek_Guinders.pl
@@ -27,12 +27,12 @@ sub EVENT_SAY {
 	if ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	if ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -41,7 +41,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18731 => 1)) {
 		quest::say("Aye. Welcome, my fur-footed friend. My name is Beek Guinders, and I am guildmaster here at the Chapel of Mischief. Here is our guild tunic. Wear it with pride, as it will set you apart from the crowd. Once you are ready to begin your training please make sure that you see Thekela Meepup, she can assist you in experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13538 - Faded Gold Felt Tunic*
-		quest::summonitem(113538);
+		quest::summonitem(13538);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/rivervale/Blinza_Toepopal.pl
+++ b/rivervale/Blinza_Toepopal.pl
@@ -18,7 +18,7 @@ sub EVENT_PROXIMITY_SAY {
 	elsif ($text=~/stew/i) {
 		quest::say("Here. Take it to Lowmot. The stew is already paid for but the good Deputy usually tips Jillin quite well. Hurry! It's getting cold!");
 		#:: Give a 13959 - Carrot Stew
-		quest::summonitem(113959);
+		quest::summonitem(13959);
 	}
 }
 
@@ -69,7 +69,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13971 => 1)) {
 		quest::say("What are these?!  I am trying to make stew for the mayor and you bring me ROTTEN CARROTS?!  Have you no sense??  Take these back to Reebo.");
 		#:: Give a 13972 - Crate of Rotten Carrots
-		quest::summonitem(113972);
+		quest::summonitem(13972);
 		#:: Set factions
 		quest::faction(241, -5);	#:: + Deeppockets
 		quest::faction(223, -1);	#:: + Circle of Unseen Hands

--- a/rivervale/Daleen_Leafsway.pl
+++ b/rivervale/Daleen_Leafsway.pl
@@ -31,7 +31,7 @@ sub EVENT_PROXIMITY_SAY {
 	if ($text=~/turnips/i) {
 		quest::say("Oh, thank you so much! You can keep any payment he gives you. Be sure to tell him I'm sorry.");
 		#:: Summon 16165 - Sack of Turnips
-		quest::summonitem(116165);
+		quest::summonitem(16165);
 	}
 }
 

--- a/rivervale/Hendi_Mrubble.pl
+++ b/rivervale/Hendi_Mrubble.pl
@@ -38,14 +38,14 @@ sub EVENT_ITEM {
 		if ($faction < 5) {
 			quest::say("May the swift and silent spirit of Fizzlethorpe Bristlebane smile upon your frail soul.");
 			#:: Give a 13936 - Squad Ring
-			quest::summonitem(113936);
+			quest::summonitem(13936);
 			#:: Ding!
 			quest::ding();
 		}
 		else {
 			quest::say("Fizzlethorpe Bristlebane only smiles upon the worthy, come back after your deeds have proven your worth.");
 			#:: Give back a 13936 - Squad Ring
-			quest::summonitem(113936);
+			quest::summonitem(13936);
 		}
 	}
 	#:: Return unused items

--- a/rivervale/Hibbs_Rootenpaw.pl
+++ b/rivervale/Hibbs_Rootenpaw.pl
@@ -19,7 +19,7 @@ sub EVENT_SAY {
 #POP	elsif ($text=~/dangers/i) {
 #POP		quest::say("The Teir'Dal, or Dark Elves, to the east have slain a number of brave Storm Reapers that are attempting to cleanse the Nektulos Forest of the corruption caused by the Teir'Dals evil magics. To the west, the human farmers in the Plains of Karana are beset upon by vicious tribes of Gnolls and must valiantly defend their farms. Closer to home the Death Fist Orcs and Goblin Clans Runnyeye and Pick Claws all attempt to control the Misty Thicket and chop down its sturdy trees for lumber. If you are planning on leaving the safety of Rivervale I advise you to deliver this note to Bartle Barnick. He will help you get yourself outfitted for survival in the wilds. When he has outfitted you in a suit of protective leather return here for [further instruction].");
 #POP		#:: Give a 19629 - Letter to Bartle Barnick
-#POP		quest::summonitem(119629);
+#POP		quest::summonitem(19629);
 #POP	}
 #POP	elsif ($text=~/further instruction/i) {
 #POP		quest::say("If you feel you are ready for the responsibility of an important task then you may assist with the [investigation] of the ancient cursed fields in the Misty Thicket. The crumbling walls that surround the cursed fields are believed to have been constructed around the same time as the ruined tower and the great wall of Cetelt. We Storm Reapers believe that the walls once surrounded beautiful and fruitful gardens. The arrogance of the caretaker of the gardens offended the Gods and in turn the gardens were cursed with disease and an evil power that animates the corpses of the dead. The Scarecrow, Old Gourdhead, stands in one of these two fields and warns passers by that it is an accursed place. Recently someone has been placing rats in the fields to become diseased.");
@@ -30,12 +30,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -44,7 +44,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18734 => 1)) {
 		quest::say("Hello, friend! I am Hibbs Rootenpaw, leader of the Storm Reapers. Our guild works together with Will Tagglefoot and his family on their farm, to produce the food supply for all of Rivervale. With Karana's help, we have a bountiful harvest every season. We're glad you could help us out. Here's your guild tunic, it'll help keep you dry during the wet months. Go find Reebo out in the fields. He'll help get you started. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13541 - Jumjum Sack Tunic*
-		quest::summonitem(113541);
+		quest::summonitem(13541);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience
@@ -59,7 +59,7 @@ sub EVENT_ITEM {
 #POP	elsif (plugin::takeItems(19689 => 1)) {
 #POP		quest::say("Excellent work young Storm Reaper. It is sad that one of our own would resort to such vile acts; his mind must have been twisted by evil desires. Such behavior is practically unheard of among the kind people of Rivervale. Take this dull scimitar and sharpen it in the forge here at the Tagglefoots Farm with a sharpening stone. It may take several attempts if you are unfamiliar with the process. Once that is done give the sharpened scimitar and a large fruit bat wing to Bodbin Gimple and he will put the finishing touches on what will be a fitting scimitar for a Druid of the Storm Reapers.");
 #POP		#:: Give a 19626 - Dull Storm Reaper Scimitar
-#POP		quest::summonitem(119626);
+#POP		quest::summonitem(19626);
 #POP		#:: Ding!
 #POP		quest::ding();
 #POP		#:: Grant a small amount of experience

--- a/rivervale/Ilscent_Tagglefoot.pl
+++ b/rivervale/Ilscent_Tagglefoot.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 	elsif ($text=~/jumjum juice/i) {
 		quest::say("Oh, thank you so much!  His name is Xanuusus and he lives in the Plains of Karana, in the foothills along their northern edge, actually.  We are most grateful for your help.  Xanuusus normally rewards messengers well.");
 		#:: Give a 13411 - Case of Jumjum Juice
-		quest::summonitem(113411);
+		quest::summonitem(13411);
 	}
 }
 

--- a/rivervale/Kaya_Cloudfoot.pl
+++ b/rivervale/Kaya_Cloudfoot.pl
@@ -20,12 +20,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18431 => 1)) {
 		quest::say("Karana smiles upon you young $name! Take this tunic to keep you warm through the storms you must face. There is evil encroaching upon the lands of Karana's faithful. The wicked minions of Bertoxxulous and the Teir'Dal children of Hate corrupt the lands to the west and east, and the Deathfist Clan of Orcs are waging war on this region while destoying the wilderness for lumber and stone. It is Karana's will that we defend our lands and way of life from these evil threats. When you are ready to begin adventuring, I will be happy to advise you on how to help us deal with the [evil forces]. I also posses knowledge of various [trades], seek me out when you wish to learn about them.");
 		#:: Give a 13541 - Jumjum Sack Tunic*
-		quest::summonitem(113541);
+		quest::summonitem(13541);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/rivervale/Kizzie_Mintopp.pl
+++ b/rivervale/Kizzie_Mintopp.pl
@@ -24,7 +24,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItemsCoin(0, 0, 30, 0, 13953 => 3)) {
 		quest::say("You are one lucky bixie buster. I just made a batch of honey jum. Here. No waiting for you.  One jar for your good work. Bye, now!");
 		#:: Give item 13952 - Honey Jum
-		quest::summonitem(113952);
+		quest::summonitem(13952);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/rivervale/Lendel_Deeppockets.pl
+++ b/rivervale/Lendel_Deeppockets.pl
@@ -17,12 +17,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Summon Item - Tradeskill Basics volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Summon Item - Tradeskill Basics volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -39,7 +39,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18732 => 1)) {
 		quest::say("HA! I asked that fool Denry to send me a professional, and this is what I get?!? Oh diddlepicks! That crotchety old coot never liked me anyway. And after all I've done for him! Hrrmf! Ah well, let's get you started and see what ya got, huh, kid? Here, wear this. Maybe I'll have Toelia break you in, huh? Yeah, that'll work! Go find her, and she'll put you to work. Just remember, we all earn our keep around here, or else it's back to hay farm for you! Oh yeah, tell her you're the new dishwasher so she knows you are on the level. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13539 - Old Brown Vest*
-		quest::summonitem(113539);
+		quest::summonitem(13539);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/rivervale/Marshal_Anrey.pl
+++ b/rivervale/Marshal_Anrey.pl
@@ -27,7 +27,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13749 => 1, 13761 => 1, 13075 => 1, 13756 => 1)) {
 		quest::say("Good work, $name. You passed the first test. If you think you are one of us, return this cap to me along with a dagger from a Dark Elf for your true reward.");
 		#:: Give a 13941 - Leatherfoot Skullcap
-		quest::summonitem(113941);
+		quest::summonitem(13941);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a moderate amount of experience
@@ -41,7 +41,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13942 => 1, 13941 => 1)) {
 		quest::say("Wonderful, $name. You have proven yourself to the Leatherfoot Squad. Take this and wear it with honor.");
 		#:: Give item 12259 - Leatherfoot Raider Skullcap
-		quest::summonitem(112259);
+		quest::summonitem(12259);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a large amount of experience

--- a/rivervale/Marshal_Ghobber.pl
+++ b/rivervale/Marshal_Ghobber.pl
@@ -35,7 +35,7 @@ sub EVENT_SAY {
 			#:: Ding
 			quest::ding();
 			#:: Give 13936 - Squad Ring
-			quest::summonitem(113936);
+			quest::summonitem(13936);
 			#:: Set faction
 			quest::faction(263, -1000);  	#:: - Guardians of the Vale
 		}

--- a/rivervale/Marshal_Lanena.pl
+++ b/rivervale/Marshal_Lanena.pl
@@ -41,7 +41,7 @@ sub EVENT_ITEM {
 		if ($faction < 5) {
 			quest::say("What was I thinking?!! Piranha are coming downstream and eating our supply of fish! We have never had a problem like this!!  Where are these little beasts coming from?  For now we must collect more. Take this bag. Collect enough teeth to fill the bag. Don't worry, if it takes a while I shall reward you with the [Rantho Rapier].  We will need to examine the teeth.");
 			#:: Give a 17968 - Piranha Bag
-			quest::summonitem(117968);
+			quest::summonitem(17968);
 			#:: Ding!
 			quest::ding();
 			#:: Grant a small amount of experience
@@ -60,7 +60,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("You are not yet in good standing with the Guardians of the Vale. Continue with your good work and then we may speak.");
 			#:: Give back a 13870 - Piranha Tooth
-			quest::summonitem(113870);
+			quest::summonitem(13870);
 		}
 	}		
 	#:: Match a 12155 - Bag of Piranha Teeth
@@ -88,7 +88,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("You are not yet in good standing with the Guardians of the Vale. Continue with your good work and then we may speak.");
 			#:: Give 12155 - Bag of Piranha Teeth
-			quest::summonitem(112155);
+			quest::summonitem(12155);
 		}
 	}		
 	#:: Return unused items

--- a/rivervale/Megosh_Thistlethorn.pl
+++ b/rivervale/Megosh_Thistlethorn.pl
@@ -17,12 +17,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Give a 51121 - Tradeskill Basics : Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Give a 51122 - Tradeskill Basics : Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 }
 
@@ -31,7 +31,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18432 => 1)) {
 		quest::say("Welcome to the Storm Reapers $name! Here is a tunic to keep you warm in your travels. Rivervale, our lovely home is facing dangerous times. From both the east and west forces devoted to the evil Gods Bertoxxulous adn Innoruuk are corrupting and destroying the wilds of Norrath. Also, the Orcs of Clan Deathfist are waging war on this entire region and gathering lumber and stone for some unknown purpose. We must do our best to preserve the lands and way of life of all Karanas people. Once you are ready to begin defending the vale against the evil forces, please return to me. I also posses knowledge of various [trades], seek me out when you wish to learn about them.");
 		#:: Give a 13541 - Jumjum Sack Tunic*
-		quest::summonitem(113541);
+		quest::summonitem(13541);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/rivervale/Reebo_Leafsway.pl
+++ b/rivervale/Reebo_Leafsway.pl
@@ -13,7 +13,7 @@ sub EVENT_SAY {
 	elsif ($text=~/trail to karana's wisdom/i) {
 		quest::say("Good. First you should learn that Karana's work is just that.. work. Karana provides us with the tools but it is by the sweat of our brows that we prosper. Common sense and hard work are two things that are highly prized by our people. Time for you to sweat, young one. Take this crate of carrots over to Blinza Toepopal in the Fool's Gold. They need our finest carrots for Mayor Gubbin's stew. When you return I will teach you a lesson of the Rainkeeper.");
 		#:: Give a 13971 - Crate of Rotten Carrots
-		quest::summonitem(113971);
+		quest::summonitem(13971);
 	}
 	elsif ($text=~/crops/i) {
 		quest::say("The crops we grow here are mostly carrots, lettuce and squash. We also are the only place on all of Norrath where the soil can support the mystical Jumjum Stalk.");
@@ -46,7 +46,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13971 => 1)) {
 		quest::say("Very good. Very good indeed. Karana does not need the blind obedience that so many deities require. Trust your instincts, they are more often right than not. Here, take this to Blinza. Hurry, she is expecting them. You may keep the donation she gives you in return.");
 		#:: Give a 13957 - Crate of Fine Carrots
-		quest::summonitem(113957);
+		quest::summonitem(13957);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a tiny amount of experience
@@ -56,7 +56,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13972 => 1)) {
 		quest::say("These carrots are rotten. They were rotten when I gave them to you. Why would you waste time and energy on such a fool's errand? Because I asked you to? Many, even those you trust will ask you to do things which you should not. Use the common sense that Karana has blessed you with to know which tasks can benefit our people and which could harm them. Learn this lesson well. You will need it if you plan to adventure beyond the vale. Now take these fresh carrots to Blinza and apologize for your error. You may keep the donation she gives you as payment.");
 		#:: Give a 13958 - Crate of Carrots
-		quest::summonitem(113958);
+		quest::summonitem(13958);
 		#:: Ding!
 		quest::ding();
 	}
@@ -84,25 +84,25 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13974 => 3)) {
 		quest::say("Oh good! I see you have taugh that nasty Nillipuss a thing or two! Good. But it seems to me that he has stolen more jumjum than this. Perhaps he needs another lesson?");
 		#:: Give a 13974 - Jumjum Stalk
-		quest::summonitem(113974);
+		quest::summonitem(13974);
 		#:: Give a 13974 - Jumjum Stalk
-		quest::summonitem(113974);
+		quest::summonitem(13974);
 		#:: Give a 13974 - Jumjum Stalk
-		quest::summonitem(113974);
+		quest::summonitem(13974);
 	}
 	#:: Match two 13974 - Jumjum Stalk
 	elsif (plugin::takeItems(13974 => 2)) {
 		quest::say("Oh good! I see you have taugh that nasty Nillipuss a thing or two! Good. But it seems to me that he has stolen more jumjum than this. Perhaps he needs another lesson?");
 		#:: Give a 13974 - Jumjum Stalk
-		quest::summonitem(113974);
+		quest::summonitem(13974);
 		#:: Give a 13974 - Jumjum Stalk
-		quest::summonitem(113974);
+		quest::summonitem(13974);
 	}
 	#:: Match two 13974 - Jumjum Stalk
 	elsif (plugin::takeItems(13974 => 1)) {
 		quest::say("Oh good! I see you have taugh that nasty Nillipuss a thing or two! Good. But it seems to me that he has stolen more jumjum than this. Perhaps he needs another lesson?");
 		#:: Give a 13974 - Jumjum Stalk
-		quest::summonitem(113974);
+		quest::summonitem(13974);
 	}
 	#:: Return unused items
 	plugin::returnUnusedItems();

--- a/rivervale/Sheriff_Roglio.pl
+++ b/rivervale/Sheriff_Roglio.pl
@@ -22,12 +22,12 @@ sub EVENT_SAY {
 	elsif ($text=~/trades/i) {
 		quest::say("I thought you might be one who was interested in the various different trades, but which one would suit you? Ahh, alas, it would be better to let you decide for yourself, perhaps you would even like to master them all! That would be quite a feat. Well, lets not get ahead of ourselves, here, take this book. When you have finished reading it, ask me for the [second book], and I shall give it to you. Inside them you will find the most basic recipes for each trade. These recipes are typically used as a base for more advanced crafting, for instance, if you wished to be a smith, one would need to find some ore and smelt it into something usable. Good luck!");
 		#:: Tradeskills Volume I
-		quest::summonitem(151121);
+		quest::summonitem(51121);
 	}
 	elsif ($text=~/second book/i) {
 		quest::say("Here is the second volume of the book you requested, may it serve you well!");
 		#:: Tradeskills Volume II
-		quest::summonitem(151122);
+		quest::summonitem(51122);
 	}
 } 
 
@@ -36,7 +36,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18733 => 1 )) {
 		quest::say("Welcome to the Guardians of the Vale. I'm Roglio Bruth, and I run this proud little outfit. You seem to be of hearty stock, let's put you to work. Here's your guild tunic - hope it fits. Start your training right away. Once you are ready to begin please make sure that you see Dalario Blistbobble, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13540 - *Old Tan Tunic
-		quest::summonitem(113540);
+		quest::summonitem(13540);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience
@@ -52,9 +52,9 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13931 => 4 )) {
 		quest::say("Good work, Deputy $name! We shall soon rid our countryside of the goblin threat. Here are your wages. Eat well tonight!");
 		#:: Give item 13023 - Bixie Berry Buns
-		quest::summonitem(113023);
+		quest::summonitem(13023);
 		#:: Give item 13024 - Tanglefoot Tingle Drink
-		quest::summonitem(113024);
+		quest::summonitem(13024);
 		#:: Ding!
 		quest::ding();
 		#:: Give a large amount of experience

--- a/rivervale/Silna_Songsmith.pl
+++ b/rivervale/Silna_Songsmith.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 	if ($text=~/deliver mail to Freeport/i) {
 		quest::say("Take this letter to Felisity Starbright. You can find her at the bard guild hall. I'm sure she will compensate you for your trouble.");
 		#:: Summon 18159 - Bardic Letter (Freeport) 
-		quest::summonitem(118159);
+		quest::summonitem(18159);
 	}	
 }
 	

--- a/rivervale/Toelia_Snuckery.pl
+++ b/rivervale/Toelia_Snuckery.pl
@@ -54,7 +54,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Oh, hi.  Listen, um.. $name, was it?  Listen, pal,  I really don't have time for the friendly-friendly, so why don't you just move on?");
 			#:: Give a 13785 - Torn Old Pouch
-			quest::summonitem(113785);
+			quest::summonitem(13785);
 		}
 	}
 	#:: Match a 13786 - Large Ruby
@@ -80,7 +80,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("Oh, hi.  Listen, um.. $name, was it?  Listen, pal, I really don't have time for the friendly-friendly, so why don't you just move on?");
 			#:: Give a 13786 - Large Ruby
-			quest::summonitem(113786);
+			quest::summonitem(13786);
 		}
 	}	
 	#:: Return unused items

--- a/rivervale/Uner_Gnarltrunk.pl
+++ b/rivervale/Uner_Gnarltrunk.pl
@@ -5,7 +5,7 @@ sub EVENT_SAY {
 	elsif ($text=~/deputy tagil/i) {
 		quest::say("Deputy Tagil is a fine young halfling who serves the vale well. But the other day, chasing that dirty Nillipuss, he trampled some fresh Jumjum.  He promised to make amends but it must have slipped his mind.  Please take this note to him as a friendly reminder.");
 		#:: Give a 18013 - Note
-		quest::summonitem(118013); 
+		quest::summonitem(18013); 
 	}
 }
 

--- a/soltemple/Romar_Sunto.pl
+++ b/soltemple/Romar_Sunto.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 	 	if ($text=~/pouch/i) {
 			quest::say("I will lend you this coin pouch - put all 10 antique silver coins into it and combine them into the Coin of Tash.");
 			#:: Give a 17511 - Coin Pouch
-			quest::summonitem(117511);
+			quest::summonitem(17511);
 		}
 		else {
 			quest::say("Tash had a collection of ten antique silver coins that were left in different cities around the world. If you were to collect all 10 coins, I would give you a [coin pouch] that would let you combine them into the master Coin of Tash. If you are interested I will sell you a copy of the Tome of Tash, detailing where the coins were reportedly left, for a mere 50 gold.");
@@ -27,7 +27,7 @@ sub EVENT_ITEM {
     #:: Match 50 gold pieces using CheckCashPayment
     if (plugin::CheckCashPayment(5000, $copper, $silver, $gold, $platinum)) {
         quest::say("Once you combine the coins within the pouch, you must take the Coin of Tash to Tarn Vislin in the HighKeep library to get it enchanted.  Give him the coin and he will enchant it for you.");
-        quest::summonitem(118032); # Tome of Tesh
+        quest::summonitem(18032); # Tome of Tesh
         quest::ding();
         quest::faction(415, 1); # + Temple of Solusek Ro
         quest::faction(416, -1); # - Shadowed Men
@@ -43,7 +43,7 @@ sub EVENT_ITEM {
     }
     elsif (plugin::check_handin(\%itemcount, 10793 => 1)) {
         quest::say("The Coin of Tash - fully enchanted! I am in your debt. Here is the scroll of Tashania that was promised to you.");
-        quest::summonitem(115678); # Spell: Tashania
+        quest::summonitem(15678); # Spell: Tashania
         quest::ding();
         quest::faction(415, 1); # + Temple of Solusek Ro
         quest::faction(416, -1); # - Shadowed Men
@@ -51,7 +51,7 @@ sub EVENT_ITEM {
     }
     elsif (plugin::check_handin(\%itemcount, 10790 => 1)) {
         quest::say("The Coin of Tash. It is of no use to me like this. You must take the coin to Tarn Visilin in High Keep to get it enchanted.");
-        quest::summonitem(110790); # Coin of Tash
+        quest::summonitem(10790); # Coin of Tash
     }
 
     #:: Return unused items

--- a/southkarana/#Brother_Hayle.pl
+++ b/southkarana/#Brother_Hayle.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(18927 => 1)) {
 		quest::say("I am needed!! What am I doing here? I must return to the Temple of Life to commune with the Prime Healer. Rodcet Nife will give me more strength to finish this job. Thank you, young one! Take this key as a reward. Turn it into Tyokan in the temple shop. Safe journey to you!");
 		#:: Give a 13306 - T.O.L. 2020
-		quest::summonitem(113306);
+		quest::summonitem(13306);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -31,7 +31,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(18936 => 1)) {
 		quest::say("Finally!! I see that Ariska has found a noble knight to retrieve Soulfire. Per Ariska's orders I am not to give Soulfire to you until you can show me [proof of nobility]. You must honor both the Temple of Life as well as the Hall of Truth and to a high degree. Only then shall you hold Soulfire.");
 		#:: Give a 18937 - Note
-		quest::summonitem(118937);
+		quest::summonitem(18937);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/southkarana/Vhalen_Nostrolo.pl
+++ b/southkarana/Vhalen_Nostrolo.pl
@@ -21,7 +21,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13114 => 1)) {
 		quest::say("Oh, dear! I forgot to repair Cassius' lute. I shall fix and return it to him myself. Thank you for bringing this to me. Here, please return this note to Cassius. He shall be most happy. Thank you again, good citizen!");
 		#:: Give a 18803 - Note To Cassius
-		quest::summonitem(118803);
+		quest::summonitem(18803);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/southkarana/a_hermit.pl
+++ b/southkarana/a_hermit.pl
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 	if (plugin::takeItems(13854 => 1)) {
 		quest::say("Good work, my friend! I thank you and the Unkempt Druids thank you. Unfortunately I have sold the other song sheet to a traveling bard of the plains. I believe her name was Cordelia. Now be on your way. Unless you plan to [join the Unkempt Druids]..?");
 		#:: Give a 13116 - Winds of Karana sheet 1
-		quest::summonitem(113116);
+		quest::summonitem(13116);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -48,7 +48,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItems(13913 => 1)) {
 		quest::say("What fine work you do! In the name of all Norrath's beasts and of the Unkempt Druids, I thank you. No longer will there be senseless slaughter. Here is the flute.");
 		#:: Give a 13310 - Cracked Flute
-		quest::summonitem(113310);
+		quest::summonitem(13310);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/sro/Rathmana_Allin.pl
+++ b/sro/Rathmana_Allin.pl
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 	elsif (plugin::takeItemsCoin(0,0,20,0, 18808 => 1, 18809 => 1, 18810 => 1)) {
 		quest::say("A simple code. Why do you even bother Rathmana with such child's play? Here is your translation. That was the easiest twenty gold coins I ever earned.");
 		#:: Give a 18961 - Translated Parchment
-		quest::summonitem(118961);
+		quest::summonitem(18961);
 		#:: Ding!
 		quest::ding();
 		quest::faction(415, 5);		#:: + Temple of Solusek Ro

--- a/sro/Smith_Tv-ysa.pl
+++ b/sro/Smith_Tv-ysa.pl
@@ -48,7 +48,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("After all the things you've done... the things you believe in... leave my shop!");
 			#:: Return a 10300 - Lightstone
-			quest::summonitem(110300);
+			quest::summonitem(10300);
 		}
 	}
 	#:: Match a 10400 - Greater Lightstone
@@ -57,7 +57,7 @@ sub EVENT_ITEM {
 		if ($faction <= 5) {
 			quest::say("A greater lightstone? Thank you very much. Here is a 'Concordance of Research' for you.");
 			#:: Give a 17504 - Concordance of Research
-			quest::summonitem(117504);
+			quest::summonitem(17504);
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -70,7 +70,7 @@ sub EVENT_ITEM {
 		else {
 			quest::say("After all the things you've done... the things you believe in... leave my shop!");
 			#:: Return a 10400 - Greater Lightstone
-			quest::summonitem(110400);
+			quest::summonitem(10400);
 		}
 	}
 	#:: Return unused items

--- a/unrest/Candy_Man.pl
+++ b/unrest/Candy_Man.pl
@@ -24,7 +24,7 @@ sub EVENT_SAY {
 		quest::summonitem(87312,10); # Item: Ginormous Jawbreaker
 		quest::summonitem(85062); # Item: Bristlebane's Ticket of Admission
 		quest::summonitem(85067,15); # Item: Haunted Candy Apples
-		if($prize == 20){quest::summonitem(124688);}
+		if($prize == 20){quest::summonitem(24688);}
 	}
         if ($text=~/Hail/i && defined $qglobals{halloween_candyman}) {
                 quest::say("Changing your costume isn't going to work! I already gave you your candy!");


### PR DESCRIPTION
Replaces #37 -- needed to rework my local copy of ret quests.

Reapplies the find/replace globally from https://github.com/The-Heroes-Journey-EQEMU/quests-old/pull/6 to fix broken quest item ID rewards.