### PR TITLE
Only hands out emblems for class name messages if level 55 or higher

### DIFF
--- a/potranquility/Bor_Wharhammer.pl
+++ b/potranquility/Bor_Wharhammer.pl
@@ -32,132 +32,134 @@ sub EVENT_SAY {
 
   # This adds a way of requesting the emblem for a given class for situations where you're not actually the class
   # that you want to make the armor for.
-  if ($text=~/Warrior/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16267);#Warrior Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+  if ($ulevel > 54) {
+    if ($text=~/Warrior/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16267);#Warrior Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Cleric/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16271);#Cleric Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Cleric/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16271);#Cleric Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Paladin/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16269);#Paladin Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Paladin/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16269);#Paladin Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Ranger/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16272);#Ranger Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Ranger/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16272);#Ranger Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Shadowknight/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16270);#Shadowknight Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Shadowknight/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16270);#Shadowknight Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Druid/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16276);#Druid Emblem
-      quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Druid/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16276);#Druid Emblem
+        quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Monk/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16275);#Monk Emblem
-      quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Monk/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16275);#Monk Emblem
+        quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Bard/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16268);#Bard Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Bard/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16268);#Bard Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Rogue/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16273);#Rogue Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Rogue/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16273);#Rogue Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Shaman/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16274);#Shaman Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Shaman/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16274);#Shaman Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Necromancer/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16278);#Necromancer Emblem
-      quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Necromancer/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16278);#Necromancer Emblem
+        quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Wizard/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16279);#Wizard Emblem
-      quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Wizard/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16279);#Wizard Emblem
+        quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Magician/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16280);#Magician Emblem
-      quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Magician/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16280);#Magician Emblem
+        quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Enchanter/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16281);#Enchanter Emblem
-      quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Enchanter/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16281);#Enchanter Emblem
+        quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Beastlord/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(16277);#Beastlord Emblem
-      quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Beastlord/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(16277);#Beastlord Emblem
+        quest::summonitem(17185);#Druzzil's Mystical Sewing Kit
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
-  }
-  elsif ($text=~/Berserker/i) {
-    if ($client->TakeMoneyFromPP(500000, 1)) {
-      quest::summonitem(32000);#Berserker Emblem
-      quest::summonitem(17184);#Mystical Furnace of Ro
-    } else {
-      quest::say("You don't have enough coin for that, come back when you do.");
+    elsif ($text=~/Berserker/i) {
+      if ($client->TakeMoneyFromPP(500000, 1)) {
+        quest::summonitem(32000);#Berserker Emblem
+        quest::summonitem(17184);#Mystical Furnace of Ro
+      } else {
+        quest::say("You don't have enough coin for that, come back when you do.");
+      }
     }
   }
 }


### PR DESCRIPTION
This adds a check to ensure that the player is above level 55 before handing them an emblem (for parity with existing shit)