### PR TITLE
Updates Phara Dar script to prevent exploitative behavior

### DIFF
--- a/veeshan/108048.pl
+++ b/veeshan/108048.pl
@@ -5,6 +5,13 @@ sub EVENT_SPAWN {
 	quest::setnexthpevent(80);
 }
 
+sub EVENT_COMBAT {
+	# if phara leaves combat, reset the hp event to stop exploiters / cheaters / baddies
+ 	if ($combat_state == 0) {
+		quest::setnexthpevent(80);
+ 	}
+}
+
 sub EVENT_HP {
 	if($hpevent == 80) {
 		quest::spawn2(108518, 0, 0, $x, $y, $z, $h); # NPC: #Protector_of_Phara_Dar


### PR DESCRIPTION
This updates the Phara Dar script to prevent people from repeatedly re-engaging her and clearing adds to be able to fight her alone.

The change makes it so that if she leaves combat, she'll reset her script to the initial state again.